### PR TITLE
Only add pipe character to page title when config is set

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,5 +1,5 @@
 <head>
-    <title> {{.Site.Params.author}} | {{.Title}} </title>
+    <title> {{.Site.Params.author}}{{ with .Title }} | {{ . }}{{ end }} </title>
     <meta charset="utf-8">
     {{- hugo.Generator -}}
     <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">


### PR DESCRIPTION
For sites that do not specify a title field in config, the homepage will produce code like this
```html
<title> Jane Doe |  </title>
```

which looks rather wrong, and is easily fixed. This PR changes the output to 

```html
<title> Jane Doe </title>
```

which satisfies both cases.
