### PR TITLE
Make pagination sections configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,12 @@ If you want to configure the security headers for a site running on Netlify, you
   Content-Security-Policy:  base-uri 'self'; connect-src 'self'; default-src 'self'; frame-ancestors 'none'; font-src 'self' stackpath.bootstrapcdn.com; img-src 'self'; object-src 'none'; script-src 'self'; style-src 'self' stackpath.bootstrapcdn.com;
   Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
 ```
-
+### Configurable pagination section
+You can configure the pages shown on the front page by altering the `mainSections` parameter:
+```toml
+[params]
+  mainSections = ["post", "docs"]
+```
 ## License
 
 Anatole is licensed under the [MIT license](https://github.com/lxndrblz/anatole/blob/master/LICENSE).

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -20,6 +20,7 @@ profilePicture = "images/profile.jpg"
 keywords = ""
 favicon = "favicons/"
 customCss = []
+mainSections = ["post"]
 
 ## Math settings
 [params.math]

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,5 +1,5 @@
 {{ define "main" }}
-  {{ $paginator := .Paginate (where .Site.RegularPages "Type" "post") }}
+  {{ $paginator := .Paginate (where .Site.RegularPages "Type" "in" .Site.Params.mainSections) }}
   {{ range $paginator.Pages }}
   <div class="post animated fadeInDown">
     <div class="post-title">


### PR DESCRIPTION
As mentioned [in the `where` docs from `hugo`](https://gohugo.io/functions/where/#mainsections) with regards to `mainSections` comparing against `.Site.Params.mainSections` allows the users to configure it on the `config.toml` like so:

```toml
[params]
  mainSections = ["blog", "docs"]
```