### PR TITLE
fix: fix white space in partials template

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -28,7 +28,7 @@
     
     {{- $js := "" -}}
     {{- range .Site.Params.customJs -}}
-      {{- if or (in . "http://") (in . "https://")  -}}
+      {{- if or (in . "http://") (in . "https://") -}}
       <script src="{{ . | relURL }}"></script>
       {{- else -}}
         {{- $customJS := resources.Get . -}}


### PR DESCRIPTION
### Changes
- There were two half-width spaces, so I fixed it to one.

closes #43 