### PR TITLE
Add option to add Google Site Verification meta tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,13 @@ To use Google Analytics, a valid tracking code has to be added. If you don't wan
 googleAnalytics = "UA-123-45"
 ```
 
+### Google Site Verification
+To use Google Site Verification, add the following line to the `[params]`:
+```toml
+googleSiteVerify = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+```
+Replace the hash with the one Google provided you.
+
 ### Beautiful math functions
 ```toml
 ## Math settings

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -24,6 +24,8 @@ customCss = []
 customJs = []
 mainSections = ["post"]
 images = ["images/site-feature-image.png"]
+# Google Site Verification
+#googleSiteVerify = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 
 ## Math settings
 [params.math]

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -41,6 +41,11 @@
         {{- end -}}
       {{- end -}}
     {{- end -}}
+
+    {{- if isset .Params "googleSiteVerify" }}
+    <!-- Google Site Verification -->
+    <meta name="google-site-verification" content="{{ .Param "googleSiteVerify" }}">
+    {{- end -}}
     
     {{- if ne $js "" -}}
     {{- $secureJS := $js |  resources.Minify | resources.Fingerprint -}}


### PR DESCRIPTION
Please consider the following:

- Add conditional Google Site Verification meta tag.

I used a little different conditional checking style and included the parameter in the `param` field, I hope that is okay, this is what the Hugo manual tells me to do.