### PR TITLE
Fix googleSiteVerify

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -42,9 +42,9 @@
       {{- end -}}
     {{- end -}}
 
-    {{- if isset .Params "googleSiteVerify" }}
+    {{- if .Site.Params.googleSiteVerify }}
     <!-- Google Site Verification -->
-    <meta name="google-site-verification" content="{{ .Param "googleSiteVerify" }}">
+    <meta name="google-site-verification" content="{{ .Site.Params.googleSiteVerify }}">
     {{- end -}}
     
     {{- if ne $js "" -}}


### PR DESCRIPTION
Apologies! It turns out the `isset` with the `.Params` reference would always return false.

Fixed now 👍