### PR TITLE
Printer friendly CSS

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -814,7 +814,8 @@ a.btn {
     display: none;
 }
 
-@media screen and (max-width: 960px) {
+@media screen and (max-width: 960px),
+print {
     .sidebar {
         width: 100%;
         position: absolute;

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -971,3 +971,9 @@ print {
     cursor: zoom-out;
     will-change: transform;
 }
+
+@media print {
+	.page-top {
+		display: none;
+	}
+}


### PR DESCRIPTION
I added a few CSS rules that allow for the contents to be better rendered when printed.  
Short list of visual differences:

- Hid ```.page-top``` class, as it is not functional on printed paper;  
- Made the left section to be displayed vertically and only once;

Printed page, **before**:
![Before](https://user-images.githubusercontent.com/67587255/93514934-15ebbb80-f928-11ea-84a9-06e60984f61a.png)  
Printed page, **after**:
![After](https://user-images.githubusercontent.com/67587255/93514941-1a17d900-f928-11ea-90af-d965bb48745d.png)
