### PR TITLE
Make the animated loading an option in config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Anatole ![](https://img.shields.io/badge/license-MIT-blue.svg) [![Netlify Status](https://api.netlify.com/api/v1/badges/ee7a5df4-b944-4e03-853d-39219c96d484/deploy-status)](https://alexbilz.com/)
+# Anatole ![LICENSE](https://img.shields.io/badge/license-MIT-blue.svg) [![Netlify Status](https://api.netlify.com/api/v1/badges/ee7a5df4-b944-4e03-853d-39219c96d484/deploy-status)](https://alexbilz.com/)
 
 Anatole is a beautiful minimalist two-column [hugo](https://gohugo.io/) theme based on farbox-theme-Anatole.
 
@@ -6,9 +6,10 @@ Anatole is a beautiful minimalist two-column [hugo](https://gohugo.io/) theme ba
 ![Screenshot Anatole Theme (dark)](https://raw.githubusercontent.com/lxndrblz/anatole/master/images/screenshot_dark.png)
 
 ## Features
+
 Anatole's aims to be minimalistic and sleek, but still brings some great functionality.
 
-### Features include:
+### Features include
 
 - Profile picture and slogan
 - Dark mode
@@ -30,27 +31,33 @@ Anatole's aims to be minimalistic and sleek, but still brings some great functio
 - Uses Hugo pipes to process assets
 
 ## Preview the exampleSite
-```
+
+```shell
 git clone https://github.com/lxndrblz/anatole.git anatole
 cd anatole/exampleSite
 hugo server --themesDir ../..
 ```
 
 ## Quick Start
+
 1. Add the repository into your Hugo Project repository as a submodule: `git submodule add https://github.com/lxndrblz/anatole.git themes/anatole`.
-2. Configure your `config.toml`. Feel free to copy the demo `config.toml` and some content from the exampleSite. 
+2. Configure your `config.toml`. Feel free to copy the demo `config.toml` and some content from the exampleSite.
 3. Build your site with `hugo serve` and admire the result at `http://localhost:1313/`.
 
 ## Update your installation
+
 If you want to get the latest update of the `Anatole` theme please execute this command:
-```
+
+```shell
 git submodule update --remote --merge
 ```
 
 ## Modifying the config.toml
-Ìn this section I'll discuss the custom parameters available within the `config.toml`. The complete [sample](https://github.com/lxndrblz/anatole/blob/master/exampleSite/config.toml) can be found in the exampleSite folder. 
+
+Ìn this section I'll discuss the custom parameters available within the `config.toml`. The complete [sample](https://github.com/lxndrblz/anatole/blob/master/exampleSite/config.toml) can be found in the exampleSite folder.
 
 ### Profile picture and slogan
+
 ```toml
 [params]
 title = "I'm Jane Doe"
@@ -60,10 +67,13 @@ profilePicture = "images/profile.jpg"
 ```
 
 ### Favicon
+
 Add you own favicon in `static/favicons/favicon.ico`.
 
 ### Navigation items
+
 Non-content entries can be added right from the `config.toml` file.
+
 ```toml
 [menu]
 
@@ -85,17 +95,22 @@ Non-content entries can be added right from the `config.toml` file.
   identifier = "about"
   url = "/about/"
 ```
+
 ### Prefer dark theme
+
 You can easily enable the dark mode from the `config.toml` all you have to do is to set the parameter `displayMode` to `dark`. If you dont specify any displayMode, then the light version will be loaded.
 
 Please also note that returning visitors will see the theme that was last displayed to them on your site. If your user has his system configured to dark mode, then this will also take presendence over the displayMode set in the `config.toml`.
+
 ```toml
 [params]
 displayMode = "dark"
-``` 
+```
 
 ### Multilingual support
-Anatole supports multilingual page setups. All you need to do is to add the languages to your 'config.toml'. For each Language you can set the custom options like title or description. It's important to include a `LanguageName`, as it will be displayed in the main menu.  
+
+Anatole supports multilingual page setups. All you need to do is to add the languages to your 'config.toml'. For each Language you can set the custom options like title or description. It's important to include a `LanguageName`, as it will be displayed in the main menu.
+
 ```toml
 [Languages]
   [Languages.en]
@@ -109,7 +124,9 @@ Anatole supports multilingual page setups. All you need to do is to add the lang
   weight = 2
   LanguageName = "DE"
 ```
+
 There are two ways of translating your content either by adding a suffix in the filename eg. `mypost.de.md` or by setting a contentDir (a certain directory) for each language. [Link to the Hugo documentation](https://gohugo.io/content-management/multilingual/). If you want to use the option with the `contentDir`, you will have to add the `contentDir` parameter for each language:
+
 ```toml
 [languages]
   [languages.en]
@@ -117,7 +134,9 @@ There are two ways of translating your content either by adding a suffix in the 
     languageName = "EN"
     weight = 1
 ```
+
 To make sure your menu is linking to the correct localized content, make sure that you customize the menu items to inlude the language prefix. Your menu might look like the following:
+
 ```toml
 [[Languages.de.menu.main]]
 url    = "/de/"
@@ -137,30 +156,42 @@ weight = 300
 identifier = "about"
 url = "/de/about/"
 ```
+
 Anatole currently ships with support for some basic languages. Contributions for other language translations are welcome.
+
 ### :100: Google Lighthouse score
+
 The theme is optimized to adhere to the requirements checked for in the Lighthouse Audit. On my [personal site](https://www.alexbilz.com) I was able to reach a perfect 100⁄100 score.
 ![Google Lighthouse Score](https://raw.githubusercontent.com/lxndrblz/anatole/master/images/lighthouse.png)
 
 ### Comments powered by Disqus
+
 No comment section is shown on the `single.html`, unless a disqus code is specified in the `config.toml` file.
+
 ```toml
 disqusShortname = "XXX"
 ```
+
 ### Google Analytics
+
 To use Google Analytics, a valid tracking code has to be added. If you don't want to load the code, then commend out the parameter.
+
 ```toml
 googleAnalytics = "UA-123-45"
 ```
 
 ### Google Site Verification
+
 To use Google Site Verification, add the following line to the `[params]`:
+
 ```toml
 googleSiteVerify = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 ```
+
 Replace the hash with the one Google provided you.
 
 ### Beautiful math functions
+
 ```toml
 ## Math settings
 [params.math]
@@ -169,26 +200,32 @@ use = "katex"  # options: "katex", "mathjax". default is "katex".
 ```
 
 ### Twitter Cards support
+
 In order to use the full functionality of Twitter cards, you will have to define a couple of settings in the `config.toml` and the frontmatter of a page.
 
 In the `config.toml` you can configure a site feature image. This image will be displayed, if no image is defined in the frontmatter of a page.
+
 ```toml
 [params]
   images = ["images/site-feature-image.png"]
 ```
+
 To define a custom image of a page, you might want to add the following to the frontmatter of a post.
+
 ```toml
 images = ["post-cover.png"]
 ```
 
-
 ### Custom CSS
+
 You can add your custom CSS files with the `customCss` parameter of the configuration file. Put your files into the `assets/css` directory.
 
 ```toml
 customCss = ["css/custom.css", "css/styles.css"]
 ```
+
 On the user-side it will look like this:
+
 ```text
 .
 └── assets
@@ -196,13 +233,18 @@ On the user-side it will look like this:
         ├── custom.css
         └── styles.css
 ```
+
 ### Custom JavaScript
+
 You can add your custom JS files with the `customJs` parameter of the configuration file. Put your files into the `assets/js` directory.
+
 ```toml
 [params]
 customJs = ["js/hello.js", "js/world.js"]
 ```
+
 On the user-side it will look like this:
+
 ```text
 .
 └── assets
@@ -210,22 +252,28 @@ On the user-side it will look like this:
         ├── hello.js
         └── world.js
 ```
+
 `hello.js` and `world.js` will be bundled into a `custom.min.js`.
 
 You can also include links to remote javascript files (hosted on CDNs for example). But be aware, that integrity settings and minification won't be applied. Further make sure to adjust your CSP. You can load a remote script like this:
+
 ```toml
 [params]
 customJs = ["http://cdn.exmple.org/fancyscript.js"]
 ```
+
 Both approaches can even be mixed:
+
 ```toml
 [params]
 customJs = ["https://cdn.exmple.org/fancyscript.js", "js/world.js"]
 ```
+
 ### Content Security Policy
+
 The theme is compliant with most strict CSP policies out of the box. A sample CSP for an Anatole-based site would look something like this:
 
-```
+```text
 Content-Security-Policy "
   base-uri 'self';
   connect-src 'self';
@@ -238,8 +286,10 @@ Content-Security-Policy "
   style-src 'self' cdnjs.cloudflare.com;
 "
 ```
+
 If you want to configure the security headers for a site running on Netlify, you want to make sure you create a special `_headers` file in your sites static folder. The content might look like the following:
-```
+
+```text
 /*
   X-Frame-Options: DENY
   X-Clacks-Overhead: "GNU Terry Pratchett"
@@ -249,34 +299,47 @@ If you want to configure the security headers for a site running on Netlify, you
   Content-Security-Policy:  base-uri 'self'; connect-src 'self'; default-src 'self'; frame-ancestors 'none'; font-src 'self' cdnjs.cloudflare.com; img-src 'self'; object-src 'none'; script-src 'self'; style-src 'self' cdnjs.cloudflare.com;
   Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
 ```
+
 ### Configurable pagination section
+
 You can configure the pages shown on the front page by altering the `mainSections` parameter:
+
 ```toml
 [params]
   mainSections = ["post", "docs"]
 ```
+
 ### Robots.txt
+
 If you want Hugo to generate a robots.txt, you will have to set the `enableRobotsTXT` in the `config.toml` to `true`. By default a robots.txt, which allows search engine crawlers to access to any page, will be generated. It will look like this:
-```
+
+```text
 User-agent: *
 ```
-If certain sites shoud be excluded from being accessed, you might want to setup a custom robots.txt file within your `static` folder of your site. 
+
+If certain sites shoud be excluded from being accessed, you might want to setup a custom robots.txt file within your `static` folder of your site.
 
 ### Syntax highlighting
+
 This theme has support for either Hugo's lightning fast Chroma code highlighting. See the [Hugo docs](https://gohugo.io/content-management/syntax-highlighting/) for more information.
 
 To enable Chroma, add the following to your site parameters:
-```
+
+```toml
 pygmentsCodeFences = true
 pygmentsUseClasses = true
 ```
+
 Then, you can generate a different style by running:
-```
+
+```shell
 hugo gen chromastyles --style=monokailight > assets/css/syntax.css
 ```
+
 If you get any errors, make sure the `assets/css/` directory exists within your sites root folder.
 Include the newly generated `syntax.css` like a standard custom css script:
-```
+
+```toml
 [params]
 customCss = ["css/syntax.css"]
 ```
@@ -291,5 +354,5 @@ This theme is maintained by its author [Alexander Bilz](https://github.com/lxndr
 
 ## Special Thanks 🎁
 
-* Go to [Cai Cai](https://github.com/hi-caicai), for the great Anatole Farbox theme that formed the foundation for this theme.
-* Go to [Kareya Saleh](https://unsplash.com/photos/tLKOj6cNwe0) for providing the profile picture in the exampleSite.
+- Go to [Cai Cai](https://github.com/hi-caicai), for the great Anatole Farbox theme that formed the foundation for this theme.
+- Go to [Kareya Saleh](https://unsplash.com/photos/tLKOj6cNwe0) for providing the profile picture in the exampleSite.

--- a/README.md
+++ b/README.md
@@ -107,6 +107,12 @@ Please also note that returning visitors will see the theme that was last displa
 displayMode = "dark"
 ```
 
+### Disable Animations
+
+```toml
+doNotLoadAnimations = true # Animations are loaded by default
+```
+
 ### Multilingual support
 
 Anatole supports multilingual page setups. All you need to do is to add the languages to your 'config.toml'. For each Language you can set the custom options like title or description. It's important to include a `LanguageName`, as it will be displayed in the main menu.

--- a/README.md
+++ b/README.md
@@ -108,8 +108,9 @@ displayMode = "dark"
 ```
 
 ### Disable Animations
-
+You can easily disable the animations from the `config.toml`. All you have to do is to set the parameter `doNotLoadAnimations` to `true`.
 ```toml
+[params]
 doNotLoadAnimations = true # Animations are loaded by default
 ```
 

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -24,7 +24,7 @@ customCss = []
 customJs = []
 mainSections = ["post"]
 images = ["images/site-feature-image.png"]
-animatedLoading = true
+doNotLoadAnimations = false
 # Google Site Verification
 #googleSiteVerify = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -24,6 +24,7 @@ customCss = []
 customJs = []
 mainSections = ["post"]
 images = ["images/site-feature-image.png"]
+animatedLoading = true
 # Google Site Verification
 #googleSiteVerify = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,5 +1,5 @@
 {{ define "main" }}
-    <div class="archive {{ with .Site.Params.animatedLoading }} animated fadeInDown {{ end }}">
+    <div class="archive {{ with .Site.Params.doNotLoadAnimations }} . {{ else }} animated fadeInDown {{ end }}">
         <ul class="list-with-title">
             {{ range .Data.Pages.GroupByDate "2006" }}
                 <div class="listing-title">{{ .Key }}</div>

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,5 +1,5 @@
 {{ define "main" }}
-    <div class="archive animated fadeInDown">
+    <div class="archive {{ with .Site.Params.animatedLoading }} animated fadeInDown {{ end }}">
         <ul class="list-with-title">
             {{ range .Data.Pages.GroupByDate "2006" }}
                 <div class="listing-title">{{ .Key }}</div>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,5 +1,5 @@
 {{ define "main" }}
-    <div class="post animated fadeInDown">
+    <div class="post {{ with .Site.Params.animatedLoading }} animated fadeInDown {{ end }}">
         <div class="post-content">
 
             <div class="post-title">

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,5 +1,5 @@
 {{ define "main" }}
-    <div class="post {{ with .Site.Params.animatedLoading }} animated fadeInDown {{ end }}">
+    <div class="post {{ with .Site.Params.doNotLoadAnimations }} . {{ else }} animated fadeInDown {{ end }}">
         <div class="post-content">
 
             <div class="post-title">

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,7 +1,7 @@
 {{ define "main" }}
     {{ $paginator := .Paginate (where .Site.RegularPages "Type" "in" .Site.Params.mainSections) }}
     {{ range $paginator.Pages }}
-        <div class="post animated fadeInDown">
+        <div class="post {{ with .Site.Params.animatedLoading }} animated fadeInDown {{ end }}">
             <div class="post-title">
                 <h3><a href="{{ .RelPermalink }}">{{ .Title }}</a>
                 </h3>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,7 +1,7 @@
 {{ define "main" }}
     {{ $paginator := .Paginate (where .Site.RegularPages "Type" "in" .Site.Params.mainSections) }}
     {{ range $paginator.Pages }}
-        <div class="post {{ with .Site.Params.animatedLoading }} animated fadeInDown {{ end }}">
+        <div class="post {{ with .Site.Params.doNotLoadAnimations }} . {{ else }} animated fadeInDown {{ end }}">
             <div class="post-title">
                 <h3><a href="{{ .RelPermalink }}">{{ .Title }}</a>
                 </h3>

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -1,4 +1,4 @@
-<div class="page-top {{ with .Site.Params.animatedLoading }} animated fadeInDown {{ end }}">
+<div class="page-top {{ with .Site.Params.doNotLoadAnimations }} . {{ else }} animated fadeInDown {{ end }}">
     <a role="button" class="navbar-burger" data-target="navMenu" aria-label="menu" aria-expanded="false">
         <span aria-hidden="true"></span>
         <span aria-hidden="true"></span>

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -1,4 +1,4 @@
-<div class="page-top animated fadeInDown">
+<div class="page-top {{ with .Site.Params.animatedLoading }} animated fadeInDown {{ end }}">
     <a role="button" class="navbar-burger" data-target="navMenu" aria-label="menu" aria-expanded="false">
         <span aria-hidden="true"></span>
         <span aria-hidden="true"></span>

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -1,4 +1,4 @@
-<div class="sidebar {{ with .Site.Params.animatedLoading }} animated fadeInDown {{ end }}">
+<div class="sidebar{{ with .Site.Params.doNotLoadAnimations }} . {{ else }} animated fadeInDown {{ end }}">
     <div class="logo-title">
         <div class="title">
             <img src="{{ .Site.Params.profilePicture | absURL }}" alt="profile picture">

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -1,4 +1,4 @@
-<div class="sidebar animated fadeInDown">
+<div class="sidebar {{ with .Site.Params.animatedLoading }} animated fadeInDown {{ end }}">
     <div class="logo-title">
         <div class="title">
             <img src="{{ .Site.Params.profilePicture | absURL }}" alt="profile picture">


### PR DESCRIPTION
Very minor feature adding new config setting for animated loading making it simply optional.
The theme is awesome, I just honestly have to admit by brain refused to accept this animation.
The solution works as intended, although it requires users to specify the `animatedLoading` param setting it to `true` (this could be considered a breaking change for some folks that do not follow the commit logs and changelogs).

I'll give it another thought if you consider it somehow wrong and if there should be a better way to handle this.