### PR TITLE
Added possibility to disable theme switcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,13 @@ Please also note that returning visitors will see the theme that was last displa
 displayMode = "dark"
 ```
 
+### Disable Theme Switcher
+You can easily disable the theme switcher from the `config.toml`. All you have to do is to set the parameter `disableThemeSwitcher` to `true`.
+```toml
+[params]
+disableThemeSwitcher = true # Theme switcher is enabled by default
+```
+
 ### Disable Animations
 You can easily disable the animations from the `config.toml`. All you have to do is to set the parameter `doNotLoadAnimations` to `true`.
 ```toml

--- a/assets/js/anatole-header.js
+++ b/assets/js/anatole-header.js
@@ -1,53 +1,3 @@
-// initialize default value
-function getTheme() {
-    return localStorage.getItem('theme') ? localStorage.getItem('theme') : null;
-}
-
-function setTheme(style) {
-    document.documentElement.setAttribute('data-theme', style);
-    localStorage.setItem('theme', style);
-}
-
-function init() {
-    // initialize default value
-    var theme = getTheme();
-
-    // check if a prefered color theme is set for users that have never been to our site
-    const userPrefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
-    if (theme === null) {
-        if (userPrefersDark) {
-            setTheme('dark');
-        } else if (!document.documentElement.getAttribute('data-theme')) {
-            setTheme('light');
-        } else {
-            setTheme(document.documentElement.getAttribute('data-theme'));
-        }
-    } else {
-        // load a stored theme
-        if (theme == 'light') {
-            document.documentElement.setAttribute('data-theme', 'light');
-        } else {
-            document.documentElement.setAttribute('data-theme', 'dark');
-        }
-    }
-}
-
-
-// switch themes
-function switchTheme(e) {
-    var theme = getTheme();
-    if (theme == 'light') {
-        setTheme('dark');
-    } else {
-        setTheme('light');
-    }
-}
-
-document.addEventListener('DOMContentLoaded', function () {
-    var themeSwitcher = document.querySelector('.theme-switch');
-    themeSwitcher.addEventListener('click', switchTheme, false);
-}, false);
-
 document.addEventListener("DOMContentLoaded", function () {
 // Get all "navbar-burger" elements
     var $navbarBurgers = Array.prototype.slice.call(document.querySelectorAll(".navbar-burger"), 0);
@@ -64,5 +14,3 @@ document.addEventListener("DOMContentLoaded", function () {
         });
     }
 });
-
-init();

--- a/assets/js/anatole-theme-switcher.js
+++ b/assets/js/anatole-theme-switcher.js
@@ -1,0 +1,51 @@
+// initialize default value
+function getTheme() {
+    return localStorage.getItem('theme') ? localStorage.getItem('theme') : null;
+}
+
+function setTheme(style) {
+    document.documentElement.setAttribute('data-theme', style);
+    localStorage.setItem('theme', style);
+}
+
+function init() {
+    // initialize default value
+    const theme = getTheme();
+
+    // check if a preferred color theme is set for users that have never been to our site
+    const userPrefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+    if (theme === null) {
+        if (userPrefersDark) {
+            setTheme('dark');
+        } else if (!document.documentElement.getAttribute('data-theme')) {
+            setTheme('light');
+        } else {
+            setTheme(document.documentElement.getAttribute('data-theme'));
+        }
+    } else {
+        // load a stored theme
+        if (theme === 'light') {
+            document.documentElement.setAttribute('data-theme', 'light');
+        } else {
+            document.documentElement.setAttribute('data-theme', 'dark');
+        }
+    }
+}
+
+
+// switch themes
+function switchTheme() {
+    const theme = getTheme();
+    if (theme === 'light') {
+        setTheme('dark');
+    } else {
+        setTheme('light');
+    }
+}
+
+document.addEventListener('DOMContentLoaded', function () {
+    const themeSwitcher = document.querySelector('.theme-switch');
+    themeSwitcher.addEventListener('click', switchTheme, false);
+}, false);
+
+init();

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -51,12 +51,22 @@
     {{ end -}}
 
     <!-- JavaScript -->
-    {{ $anatole := resources.Get "js/anatole-header.js" }}
-    {{ $secureJS := $anatole |  resources.Minify | resources.Fingerprint }}
+    {{ $anatoleHeader := resources.Get "js/anatole-header.js" }}
+    {{ $secureHeaderJS := $anatoleHeader |  resources.Minify | resources.Fingerprint }}
     <script type="text/javascript"
-            src="{{ $secureJS.Permalink }}"
-            integrity="{{ $secureJS.Data.Integrity }}"
+            src="{{ $secureHeaderJS.Permalink }}"
+            integrity="{{ $secureHeaderJS.Data.Integrity }}"
             crossorigin="anonymous"></script>
+
+
+    {{ if not .Site.Params.disableThemeSwitcher }}
+        {{ $anatoleThemeSwitcher := resources.Get "js/anatole-theme-switcher.js" }}
+        {{ $secureThemeSwitcherJS := $anatoleThemeSwitcher |  resources.Minify | resources.Fingerprint }}
+        <script type="text/javascript"
+                src="{{ $secureThemeSwitcherJS.Permalink }}"
+                integrity="{{ $secureThemeSwitcherJS.Data.Integrity }}"
+                crossorigin="anonymous"></script>
+    {{ end }}
 
     {{- $js := "" -}}
     {{- range .Site.Params.customJs -}}

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -23,10 +23,12 @@
                 </li>
             {{ end }}
         {{ end }}
-        <li class="theme-switch-item">
-            <a class="theme-switch" title="Switch Theme">
-                <i class="fas fa-adjust fa-fw" aria-hidden="true"></i>
-            </a>
-        </li>
+        {{ if not .Site.Params.disableThemeSwitcher }}
+            <li class="theme-switch-item">
+                <a class="theme-switch" title="Switch Theme">
+                    <i class="fas fa-adjust fa-fw" aria-hidden="true"></i>
+                </a>
+            </li>
+        {{ end }}
     </ul>
 </div>


### PR DESCRIPTION
Hi @lxndrblz ,
I was thinking that since there is the possibility to set a default theme, It could also be useful to disable the theme switcher and for this reason, I opened this PR.

I split the js files so if the theme switcher is disabled, the theme-switcher javascript will not be loaded. This will help to reduce the amount of data that should be downloaded.

I also added a brief paragraph in the documentation on how to disable it.

Let me know if there is something that could be improved.