### PR TITLE
Added the possibility to configure the copyright years

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,12 @@ profilePicture = "images/profile.jpg"
 
 Add you own favicon in `static/favicons/favicon.ico`.
 
+### Copyright
+By default the copyright, will show the current year, but you can change this by configuring the `copyright` parameter.
+```toml
+copyright = "2020-2021"
+```
+
 ### Navigation items
 
 Non-content entries can be added right from the `config.toml` file.

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -21,6 +21,7 @@ pygmentsCodefencesGuessSyntax = true
 [params]
 title = "I'm Jane Doe"
 author = "Jane Doe"
+#copyright = "2020-2021"
 description = "Call me Jane"
 profilePicture = "images/profile.jpg"
 keywords = ""

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -18,6 +18,6 @@
         {{ end }}
     </ul>
     <div class="footer">
-        <div class="by_farbox">&copy; {{ .Site.Params.author }} {{ now.Format "2006"}} </div>
+        <div class="by_farbox">&copy; {{ .Site.Params.author }} {{ if isset .Site.Params "copyright" }} {{ .Site.Params.copyright }} {{ else }} {{ now.Format "2006"}} {{end}}</div>
     </div>
 </div>


### PR DESCRIPTION
Hi @lxndrblz ,
looking at the theme, I saw that it wasn't possible to specify more than one year for the copyright years.

For this reason, I added the possibility to configure the copyrights years under the configuration params but still having the current behaviour as default in case this configuration is not specified.

Let me know if there is something to improve.