### PR TITLE
reCaptcha added to contact form, animation transparency restated, per-page animation control.

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,10 @@ You can easily disable the animations from the `config.toml`. All you have to do
 [params]
 doNotLoadAnimations = true # Animations are loaded by default
 ```
+You can also turn off animations on a per-page basis by setting `animation` to `false` in the frontmatter of a page.
+```md
+animation: false
+```
 
 ### Control the date Format
 You can change the default date formating for the `list.html`, the `single.html` and the `index.html`. Simply configure the matching parameters.
@@ -267,9 +271,15 @@ use = "katex"  # options: "katex", "mathjax". default is "katex".
 Step 1: Configure the `contactFormAction` in the `config.toml`
 ```toml
 [params]
-#contactFormAction = "https://formspree.io/f/your-form-hash-here"
+contactFormAction = "https://formspree.io/f/your-form-hash-here"
 ```
 Step 2: Activate the `contact: true` or  `contact=true` in the frontmatter of a page. See `exampleSite/content/contact.html` as an example.
+Step 3: If you have configured a Google reCaptcha v2 in your formSpree form, you will want to
+put the site key in `config.toml`:
+```toml
+[params]
+contactFormReCaptchaSiteKey = "your-site-key"
+```
 ### Twitter Cards support
 
 In order to use the full functionality of Twitter cards, you will have to define a couple of settings in the `config.toml` and the frontmatter of a page.

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -14,6 +14,7 @@
     --tag-color: #424242;
     --blockquote-text-color: #858585;
     --blockquote-border-color: #dfe2e5;
+    --error-color: #ff3939;
     --thumbnail-height: 15em;
     scroll-padding-top: 100px;
 }
@@ -32,6 +33,7 @@ html[data-theme='dark'] {
     --tag-color: rgb(191, 191, 191);
     --blockquote-text-color: #808080;
     --blockquote-border-color: #424242;
+    --error-color: #ff3939;
 }
 
 html {
@@ -1052,7 +1054,7 @@ print {
     border: 1px solid var(--form-border-color);
     color: var(--body-color);
 }
-.form-style ul li    .field-style:focus {
+.form-style ul li .field-style:focus {
     box-shadow: 0 0 5px;
     border:1px solid;
 }
@@ -1090,5 +1092,13 @@ print {
     background-color: var(--bg-color);
     border: 1px solid var(--form-button-hover-border-color);
 }
-
+.form-style .form-row {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    flex: 1;
+}
+.form-style div[feedback-success="false"] {
+    color: var(--error-color);
+}
 /* (CONTACT) FORM END */

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -132,40 +132,48 @@ a:active {
 
 @-webkit-keyframes fadeInDown {
     0% {
+        opacity: 0;
         -webkit-transform: translateY(-20px);
     }
 
     100% {
+        opacity: 1;
         -webkit-transform: translateY(0);
     }
 }
 
 @-moz-keyframes fadeInDown {
     0% {
+        opacity: 0;
         -moz-transform: translateY(-20px);
     }
 
     100% {
+        opacity: 1;
         -moz-transform: translateY(0);
     }
 }
 
 @-o-keyframes fadeInDown {
     0% {
+        opacity: 0;
         -o-transform: translateY(-20px);
     }
 
     100% {
+        opacity: 1;
         -o-transform: translateY(0);
     }
 }
 
 @keyframes fadeInDown {
     0% {
+        opacity: 0;
         transform: translateY(-20px);
     }
 
     100% {
+        opacity: 1;
         transform: translateY(0);
     }
 }

--- a/i18n/de.toml
+++ b/i18n/de.toml
@@ -20,5 +20,32 @@ other = "Du kannst hier zurück zur <a href=\"{{ . }}\">Startseite</a>."
 [comments]
 other = "Kommentare"
 
+[name]
+other = "Name"
+
+[name_error]
+other = "Please provide your name"
+
+[email]
+other = "Email"
+
+[email_error]
+other = "Please enter a valid email address"
+
+[message]
+other = "Message"
+
+[message_error]
+other = "Please let us know why you are contacting us"
+
 [send]
 other = "Senden"
+
+[form_captcha_error]
+other = "Captcha error; please try again later"
+
+[form_submit_error]
+other = "Fatal error, contact not made - please reach out some other way"
+
+[form_success]
+other = "Thank you for reaching out! We will be touch soon"

--- a/i18n/dk.toml
+++ b/i18n/dk.toml
@@ -20,5 +20,32 @@ other = "Returner til <a href=\"{{ . }}\">homepage</a>."
 [comments]
 other = "kommentar"
 
+[name]
+other = "Name"
+
+[name_error]
+other = "Please provide your name"
+
+[email]
+other = "Email"
+
+[email_error]
+other = "Please enter a valid email address"
+
+[message]
+other = "Message"
+
+[message_error]
+other = "Please let us know why you are contacting us"
+
 [send]
 other = "Sende"
+
+[form_captcha_error]
+other = "Captcha error; please try again later"
+
+[form_submit_error]
+other = "Fatal error, contact not made - please reach out some other way"
+
+[form_success]
+other = "Thank you for reaching out! We will be touch soon"

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -20,5 +20,32 @@ other = "You can head back to <a href=\"{{ . }}\">homepage</a>."
 [comments]
 other = "comments"
 
+[name]
+other = "Name"
+
+[name_error]
+other = "Please provide your name"
+
+[email]
+other = "Email"
+
+[email_error]
+other = "Please enter a valid email address"
+
+[message]
+other = "Message"
+
+[message_error]
+other = "Please let us know why you are contacting us"
+
 [send]
 other = "Send"
+
+[form_captcha_error]
+other = "Captcha error; please try again later"
+
+[form_submit_error]
+other = "Fatal error, contact not made - please reach out some other way"
+
+[form_success]
+other = "Thank you for reaching out! We will be touch soon"

--- a/i18n/es.toml
+++ b/i18n/es.toml
@@ -20,5 +20,32 @@ other = "Puedes regresar a la <a href=\"{{ . }}\">página inicial</a>."
 [comments]
 other = "comentarios"
 
+[name]
+other = "Name"
+
+[name_error]
+other = "Please provide your name"
+
+[email]
+other = "Email"
+
+[email_error]
+other = "Please enter a valid email address"
+
+[message]
+other = "Message"
+
+[message_error]
+other = "Please let us know why you are contacting us"
+
 [send]
 other = "Enviar"
+
+[form_captcha_error]
+other = "Captcha error; please try again later"
+
+[form_submit_error]
+other = "Fatal error, contact not made - please reach out some other way"
+
+[form_success]
+other = "Thank you for reaching out! We will be touch soon"

--- a/i18n/fa.toml
+++ b/i18n/fa.toml
@@ -20,5 +20,32 @@ other = "شما می‌توانید برگردید به <a href=\"{{ . }}\">صف
 [comments]
 other = "نظرات"
 
+[name]
+other = "Name"
+
+[name_error]
+other = "Please provide your name"
+
+[email]
+other = "Email"
+
+[email_error]
+other = "Please enter a valid email address"
+
+[message]
+other = "Message"
+
+[message_error]
+other = "Please let us know why you are contacting us"
+
 [send]
 other = "ارسال"
+
+[form_captcha_error]
+other = "Captcha error; please try again later"
+
+[form_submit_error]
+other = "Fatal error, contact not made - please reach out some other way"
+
+[form_success]
+other = "Thank you for reaching out! We will be touch soon"

--- a/i18n/fi.toml
+++ b/i18n/fi.toml
@@ -20,5 +20,32 @@ other = "Voit palata takaisin <a href=\"{{ . }}\">kotisivulle</a>."
 [comments]
 other = "kommentit"
 
+[name]
+other = "Name"
+
+[name_error]
+other = "Please provide your name"
+
+[email]
+other = "Email"
+
+[email_error]
+other = "Please enter a valid email address"
+
+[message]
+other = "Message"
+
+[message_error]
+other = "Please let us know why you are contacting us"
+
 [send]
 other = "Lähetä"
+
+[form_captcha_error]
+other = "Captcha error; please try again later"
+
+[form_submit_error]
+other = "Fatal error, contact not made - please reach out some other way"
+
+[form_success]
+other = "Thank you for reaching out! We will be touch soon"

--- a/i18n/fr.toml
+++ b/i18n/fr.toml
@@ -20,5 +20,32 @@ other = "Vous pouvez revenir à <a href=\"{{ . }}\">l'accueil</a>."
 [comments]
 other = "commentaire"
 
+[name]
+other = "Name"
+
+[name_error]
+other = "Please provide your name"
+
+[email]
+other = "Email"
+
+[email_error]
+other = "Please enter a valid email address"
+
+[message]
+other = "Message"
+
+[message_error]
+other = "Please let us know why you are contacting us"
+
 [send]
 other = "Envoyer"
+
+[form_captcha_error]
+other = "Captcha error; please try again later"
+
+[form_submit_error]
+other = "Fatal error, contact not made - please reach out some other way"
+
+[form_success]
+other = "Thank you for reaching out! We will be touch soon"

--- a/i18n/it.toml
+++ b/i18n/it.toml
@@ -20,5 +20,32 @@ other = "Puoi tornare alla <a href=\"{{ . }}\">homepage</a>."
 [comments]
 other = "commenti"
 
+[name]
+other = "Name"
+
+[name_error]
+other = "Please provide your name"
+
+[email]
+other = "Email"
+
+[email_error]
+other = "Please enter a valid email address"
+
+[message]
+other = "Message"
+
+[message_error]
+other = "Please let us know why you are contacting us"
+
 [send]
 other = "Spedire"
+
+[form_captcha_error]
+other = "Captcha error; please try again later"
+
+[form_submit_error]
+other = "Fatal error, contact not made - please reach out some other way"
+
+[form_success]
+other = "Thank you for reaching out! We will be touch soon"

--- a/i18n/pt-br.toml
+++ b/i18n/pt-br.toml
@@ -20,5 +20,32 @@ other = "Retornar à <a href=\"{{ . }}\">página inicial</a>."
 [comments]
 other = "comentários"
 
+[name]
+other = "Name"
+
+[name_error]
+other = "Please provide your name"
+
+[email]
+other = "Email"
+
+[email_error]
+other = "Please enter a valid email address"
+
+[message]
+other = "Message"
+
+[message_error]
+other = "Please let us know why you are contacting us"
+
 [send]
 other = "Enviar"
+
+[form_captcha_error]
+other = "Captcha error; please try again later"
+
+[form_submit_error]
+other = "Fatal error, contact not made - please reach out some other way"
+
+[form_success]
+other = "Thank you for reaching out! We will be touch soon"

--- a/i18n/zh-cn.toml
+++ b/i18n/zh-cn.toml
@@ -20,5 +20,32 @@ other = "返回<a href=\"{{ . }}\">首页</a>."
 [comments]
 other = "评论"
 
+[name]
+other = "Name"
+
+[name_error]
+other = "Please provide your name"
+
+[email]
+other = "Email"
+
+[email_error]
+other = "Please enter a valid email address"
+
+[message]
+other = "Message"
+
+[message_error]
+other = "Please let us know why you are contacting us"
+
 [send]
 other = "发送"
+
+[form_captcha_error]
+other = "Captcha error; please try again later"
+
+[form_submit_error]
+other = "Fatal error, contact not made - please reach out some other way"
+
+[form_success]
+other = "Thank you for reaching out! We will be touch soon"

--- a/i18n/zh-tw.toml
+++ b/i18n/zh-tw.toml
@@ -20,5 +20,32 @@ other = "返回 <a href=\"{{ . }}\">首頁</a>."
 [comments]
 other = "註解"
 
+[name]
+other = "Name"
+
+[name_error]
+other = "Please provide your name"
+
+[email]
+other = "Email"
+
+[email_error]
+other = "Please enter a valid email address"
+
+[message]
+other = "Message"
+
+[message_error]
+other = "Please let us know why you are contacting us"
+
 [send]
 other = "發送"
+
+[form_captcha_error]
+other = "Captcha error; please try again later"
+
+[form_submit_error]
+other = "Fatal error, contact not made - please reach out some other way"
+
+[form_success]
+other = "Thank you for reaching out! We will be touch soon"

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,5 +1,5 @@
 {{ define "main" }}
-    <div class="archive {{ with .Site.Params.doNotLoadAnimations }} . {{ else }} animated fadeInDown {{ end }}">
+    <div class="archive {{ if and (or (not (isset .Site.Params "doNotLoadAnimations")) (and (isset .Site.Params "doNotLoadAnimations") (not .Site.Params.doNotLoadAnimations))) (or (not (isset .Page.Params "animation")) .Page.Params.animation) }} animated fadeInDown {{ end }}">
         <ul class="list-with-title">
             {{ range .Data.Pages.GroupByDate "2006" }}
                 <div class="listing-title">{{ .Key }}</div>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,5 +1,5 @@
 {{ define "main" }}
-    <div class="post {{ with .Site.Params.doNotLoadAnimations }} . {{ else }} animated fadeInDown {{ end }}">
+    <div class="post {{ if and (or (not (isset .Site.Params "doNotLoadAnimations")) (and (isset .Site.Params "doNotLoadAnimations") (not .Site.Params.doNotLoadAnimations))) (or (not (isset .Page.Params "animation")) .Page.Params.animation) }} animated fadeInDown {{ end }}">
         <div class="post-content">
             {{ if .Params.thumbnail }}
             <img class="post-thumbnail" src="{{ .Params.thumbnail | absURL }}" alt="Thumbnail image">

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,6 +1,6 @@
 {{ define "main" }}
 
-    <div class="post {{ with .Site.Params.doNotLoadAnimations }} . {{ else }} animated fadeInDown {{ end }}">
+    <div class="post {{ if and (or (not (isset .Site.Params "doNotLoadAnimations")) (and (isset .Site.Params "doNotLoadAnimations") (not .Site.Params.doNotLoadAnimations))) (or (not (isset .Page.Params "animation")) .Page.Params.animation) }} animated fadeInDown {{ end }}">
         <!-- (Optional) Home
             -- on top of `mainSections` content (aka posts) ;
             -- as declared in content/_index.md
@@ -13,7 +13,7 @@
     {{ $paginator := .Paginate (where .Site.RegularPages "Type" "in" .Site.Params.mainSections) }}
     {{ range $paginator.Pages }}
 
-        <div class="post {{ with .Site.Params.doNotLoadAnimations }} . {{ else }} animated fadeInDown {{ end }}">
+        <div class="post {{ if and (or (not (isset .Site.Params "doNotLoadAnimations")) (and (isset .Site.Params "doNotLoadAnimations") (not .Site.Params.doNotLoadAnimations))) (or (not (isset .Page.Params "animation")) .Page.Params.animation) }} animated fadeInDown {{ end }}">
             {{ if .Params.thumbnail }}
             <div class="post-thumbnail">
                 <a href="{{ .RelPermalink }}">

--- a/layouts/partials/contact.html
+++ b/layouts/partials/contact.html
@@ -16,15 +16,17 @@
       <li>
         <input class="field-style" id="form-submit" type="submit" value="{{ i18n "send" }}">
       </li>
+      {{ with .Site.Params.contactFormReCaptchaSiteKey }}
+      <li>
+        <div id="g-recaptcha"></div>
+      </li>
+      {{ end }}
       <li>
         <div id="submit-feedback"></div>
       </li>
     </ul>
   </form>
 </div>
-{{ with .Site.Params.contactFormReCaptchaSiteKey }}
-  <div id="g-recaptcha"></div>
-{{ end }}
 
 <script>
   // Sets feedback message.

--- a/layouts/partials/contact.html
+++ b/layouts/partials/contact.html
@@ -1,5 +1,5 @@
-<script src="https://www.google.com/recaptcha/api.js" async defer></script>
-<script type="text/javascript" src="http://code.jquery.com/jquery-3.5.1.min.js"></script>
+<script type="text/javascript" src="https://www.google.com/recaptcha/api.js" async defer></script>
+<script type="text/javascript" src="/assets/js/jquery.js"></script>
 
 <div class="contact-form">
   <form id="contact-form" class="form-style" method="POST" action="{{ .Site.Params.contactFormAction }}">

--- a/layouts/partials/contact.html
+++ b/layouts/partials/contact.html
@@ -21,7 +21,7 @@
       </li>
     </ul>
     {{ with .Site.Params.contactFormReCaptchaSiteKey }}
-      <div class="g-recaptcha" data-sitekey="{{ . }}" data-callback="onSubmit" data-size="invisible" data-theme=""></div>
+      <div class="g-recaptcha" data-sitekey="{{ . }}" data-callback="onSubmit" data-size="invisible" data-theme="{{ $.Page.Params.data-theme }}"></div>
     {{ end }}
   </form>
 </div>

--- a/layouts/partials/contact.html
+++ b/layouts/partials/contact.html
@@ -1,19 +1,80 @@
+<script src="https://www.google.com/recaptcha/api.js" async defer></script>
+<script type="text/javascript" src="http://code.jquery.com/jquery-3.5.1.min.js"></script>
 
 <div class="contact-form">
-  <form class="form-style" method="POST" action="{{ .Site.Params.contactFormAction }}" data-toggle="validator">
+  <form id="contact-form" class="form-style" method="POST" action="{{ .Site.Params.contactFormAction }}">
     <ul>
       <li>
-        <input class="field-style field-full" type="text" name="username" id="username" placeholder="Name" required>
+        <input class="field-style field-full" type="text" name="username" id="username" placeholder="{{ i18n "name" }}" oninvalid="setCustomValidity('{{ i18n "name_error" }}')" oninput="setCustomValidity('')" required>
       </li>
       <li>
-        <input class="field-style field-full" type="email" id="email" name="email" placeholder="Email" required>
+        <input class="field-style field-full" type="email" name="email" id="email" placeholder="{{ i18n "email" }}" pattern="^[a-zA-Z0-9.!#$%&’*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$" oninvalid="setCustomValidity('{{ i18n "email_error" }}')" oninput="setCustomValidity('')" required>
       </li>
       <li>
-        <textarea class="field-style" name="message" id="message" rows="6" placeholder="{{ i18n "message" }}"></textarea>
+        <textarea class="field-style" name="message" id="message" rows="6" placeholder="{{ i18n "message" }}" oninvalid="setCustomValidity('{{ i18n "message_error" }}')" oninput="setCustomValidity('')" required></textarea>
       </li>
       <li>
-        <input class="field-style" type="submit" value="{{ i18n "send" }}"></input>
+        <input class="field-style" id="form-submit" type="submit" value="{{ i18n "send" }}">
+      </li>
+      <li>
+        <div id="submit-feedback"></div>
       </li>
     </ul>
+    {{ with .Site.Params.contactFormReCaptchaSiteKey }}
+      <div class="g-recaptcha" data-sitekey="{{ . }}" data-callback="onSubmit" data-size="invisible" data-theme=""></div>
+    {{ end }}
   </form>
 </div>
+
+<script>
+  // Sets feedback message.
+  function setFeedback(message = '', ok = true) {
+    const feedback = $('#submit-feedback');
+
+    feedback.attr('feedback-success', ok);
+    feedback.text(message);
+  }
+
+  // This hanlder takes care of submission post-captcha.
+  function onSubmit() {
+    // Verify if we have a recaptcha at all before checking.
+    if($('.g-recaptcha')[0] !== null &&
+      grecaptcha.getResponse().length == 0) { 
+      setFeedback('{{ i18n "form_captcha_error" }}', false);
+    } else {
+      const message = $('#contact-form').serialize();
+
+      $.ajax({
+          url: '{{ .Site.Params.contactFormAction }}', 
+          method: 'POST',
+          data: message,
+          dataType: 'json',
+          success: (result) => {
+            setFeedback('{{ i18n "form_success" }}');
+          },
+          error: (xhr) => {
+            setFeedback('{{ i18n "form_submit_error" }}', false);
+          },
+      });
+
+      // Enable button.
+      $('#form-submit').prop('disabled', false);
+    }
+  }
+
+  // Initial contact form submit is disabled, and optionally kicks off captcha.
+  $('#contact-form').submit((e) => {
+    // We're doing the submission to avoid the redirect for free Formspree accounts.
+    e.preventDefault();
+    setFeedback('');
+    // Disable submit button for the time being,
+    $('#form-submit').prop('disabled', true);
+  
+    // Make sure we have a captcha to execute before trying to do so.
+    if ($('.g-recaptcha')[0] !== null) {
+      grecaptcha.execute();
+    } else {
+      onSubmit();
+    }
+  });
+</script>

--- a/layouts/partials/contact.html
+++ b/layouts/partials/contact.html
@@ -21,7 +21,7 @@
       </li>
     </ul>
     {{ with .Site.Params.contactFormReCaptchaSiteKey }}
-      <div class="g-recaptcha" data-sitekey="{{ . }}" data-callback="onSubmit" data-size="invisible" data-theme="{{ $.Page.Params.data-theme }}"></div>
+      <div class="g-recaptcha" data-sitekey="{{ . }}" data-callback="onSubmit" data-size="invisible" data-theme=""></div>
     {{ end }}
   </form>
 </div>

--- a/layouts/partials/contact.html
+++ b/layouts/partials/contact.html
@@ -1,5 +1,5 @@
-<script type="text/javascript" src="https://www.google.com/recaptcha/api.js" async defer></script>
-<script type="text/javascript" src="/assets/js/jquery.js"></script>
+{{ $jquery := resources.Get "js/jquery.js" }}
+<script type="text/javascript" src="{{ $jquery.Permalink }}"></script>
 
 <div class="contact-form">
   <form id="contact-form" class="form-style" method="POST" action="{{ .Site.Params.contactFormAction }}">
@@ -20,11 +20,11 @@
         <div id="submit-feedback"></div>
       </li>
     </ul>
-    {{ with .Site.Params.contactFormReCaptchaSiteKey }}
-      <div class="g-recaptcha" data-sitekey="{{ . }}" data-callback="onSubmit" data-size="invisible" data-theme=""></div>
-    {{ end }}
   </form>
 </div>
+{{ with .Site.Params.contactFormReCaptchaSiteKey }}
+  <div id="g-recaptcha"></div>
+{{ end }}
 
 <script>
   // Sets feedback message.
@@ -78,3 +78,21 @@
     }
   });
 </script>
+
+{{ with .Site.Params.contactFormReCaptchaSiteKey }}
+  <script>
+      // Captcha rendered dynamically to deal with some rendering issues with
+      // theme and with animation.
+      function captchaLoadCallback() {
+        grecaptcha.render( 'g-recaptcha', {
+          sitekey: '{{ . }}',
+          callback: onSubmit,
+          size: 'invisible',
+          badge: 'bottomright',
+          theme: $('html').attr('data-theme'),
+        });
+      }
+  </script>
+  <!-- Explicit rendering of recaptcha to deal with data-theme and animation issues -->
+  <script type="text/javascript" src="https://www.google.com/recaptcha/api.js?onload=captchaLoadCallback&render=explicit" async defer></script>
+{{ end }}

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -1,4 +1,4 @@
-<div class="page-top {{ with .Site.Params.doNotLoadAnimations }} . {{ else }} animated fadeInDown {{ end }}">
+<div class="page-top {{ if and (or (not (isset .Site.Params "doNotLoadAnimations")) (and (isset .Site.Params "doNotLoadAnimations") (not .Site.Params.doNotLoadAnimations))) (or (not (isset .Page.Params "animation")) .Page.Params.animation) }} animated fadeInDown {{ end }}">
     <a role="button" class="navbar-burger" data-target="navMenu" aria-label="menu" aria-expanded="false">
         <span aria-hidden="true"></span>
         <span aria-hidden="true"></span>

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -1,4 +1,4 @@
-<div class="sidebar{{ with .Site.Params.doNotLoadAnimations }} . {{ else }} animated fadeInDown {{ end }}">
+<div class="sidebar{{ if and (or (not (isset .Site.Params "doNotLoadAnimations")) (and (isset .Site.Params "doNotLoadAnimations") (not .Site.Params.doNotLoadAnimations))) (or (not (isset .Page.Params "animation")) .Page.Params.animation) }} animated fadeInDown {{ end }}">
     <div class="logo-title">
         <div class="title">
             <img src="{{ .Site.Params.profilePicture | absURL }}" alt="profile picture">


### PR DESCRIPTION
My apologies for incorporating two features into the same pull request.

Documentation complete. i18n placeholders put in each language, but not translated.

To see the changes you have to add a captcha site key to `config.toml`. After that the captcha should show up on the contact form. Turning on or off animation will show the transparency effect and also show the captcha jumping. You can now turn off animation on a per-page basis in the frontmatter.

Carmine