### PR TITLE
Formspree, Netlify forms with spam protection.

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,9 +269,10 @@ Step 1: Configure the `contactFormAction` in the `config.toml`
 contactFormAction = "https://formspree.io/f/your-form-hash-here"
 ```
 Step 2: Activate the `contact: true` or  `contact=true` in the frontmatter of a page. See `exampleSite/content/contact.html` as an example.
-Step 3: If you wish to use a Google reCaptcha v2, you must [go to a Google Admin console](https://www.google.com/recaptcha/about/) and create a reCaptcha:
-Make sure it is a reCaptcha v2. You must then [go to your Formspree account](https://help.formspree.io/hc/en-us/articles/360022811154-Adding-a-custom-reCAPTCHA-key) and enter the secret key that you were given in the appropriate location.
-Step 4: Enter the recaptcha site key in `config.toml`:
+
+Step 3: If you wish to use a Google reCAPTCHA v2, you must [go to a Google Admin console](https://www.google.com/recaptcha/about/) and create a reCAPTCHA:
+Make sure it is a reCAPTCHA v2. You must then [go to your Formspree account](https://help.formspree.io/hc/en-us/articles/360022811154-Adding-a-custom-reCAPTCHA-key) and enter the secret key that you were given in the appropriate location.
+Step 4: Enter the reCAPTCHA site key in `config.toml`:
 ```toml
 [params]
 contactFormReCaptchaSiteKey = "your-site-key"
@@ -284,14 +285,17 @@ Step 1: Configure the `contactFormType` in the `config.toml`. Netlify does not r
 contactFormType = "netlify"
 ```
 Step 2: Set `contact: true` or  `contact=true` in the frontmatter of a page. See `exampleSite/content/contact.html` as an example.
-Step 3: If you wish to use a Google reCaptcha v2, you must [go to a Google Admin console](https://www.google.com/recaptcha/about/) and create a reCaptcha.
-Make sure it is a reCaptcha v2. You must then [go to your Formspree account](https://help.formspree.io/hc/en-us/articles/360022811154-Adding-a-custom-reCAPTCHA-key) and enter the secret key that you were given in the appropriate location.
-Step 4: Enter the recaptcha site key in `config.toml`:
+
+Step 3: If you wish to use a Google reCAPTCHA v2, you must [go to a Google Admin console](https://www.google.com/recaptcha/about/) and create a reCAPTCHA.
+Make sure it is a reCAPTCHA v2. You must then [go to your Formspree account](https://help.formspree.io/hc/en-us/articles/360022811154-Adding-a-custom-reCAPTCHA-key) and enter the secret key that you were given in the appropriate location.
+
+Step 4: Enter the reCAPTCHA site key in `config.toml`:
 ```toml
 [params]
 contactFormReCaptchaSiteKey = "your-site-key"
 ```
-Step 5: [Go to your Netlify account](https://www.netlify.com/blog/2018/05/23/bring-your-own-recaptcha-to-netlify-forms/) and let them know both the site key and the secret key for your custom recaptcha.
+Step 5: [Go to your Netlify account](https://www.netlify.com/blog/2018/05/23/bring-your-own-recaptcha-to-netlify-forms/) and let them know both the site key and the secret key for your custom reCAPTCHA.
+
 Step 6: You will probably want to set up some [form notification](https://docs.netlify.com/forms/notifications/).
 
 ### Twitter Cards support

--- a/README.md
+++ b/README.md
@@ -274,12 +274,31 @@ Step 1: Configure the `contactFormAction` in the `config.toml`
 contactFormAction = "https://formspree.io/f/your-form-hash-here"
 ```
 Step 2: Activate the `contact: true` or  `contact=true` in the frontmatter of a page. See `exampleSite/content/contact.html` as an example.
-Step 3: If you have configured a Google reCaptcha v2 in your formSpree form, you will want to
-put the site key in `config.toml`:
+Step 3: If you wish to use a Google reCaptcha v2, you must [go to a Google Admin console](https://www.google.com/recaptcha/about/) and create a reCaptcha:
+Make sure it is a reCaptcha v2. You must then [go to your Formspree account](https://help.formspree.io/hc/en-us/articles/360022811154-Adding-a-custom-reCAPTCHA-key) and enter the secret key that you were given in the appropriate location.
+Step 4: Enter the recaptcha site key in `config.toml`:
 ```toml
 [params]
 contactFormReCaptchaSiteKey = "your-site-key"
 ```
+### Netlify Contact Form on the Contact Page
+Netlify forms only work when your site is being actively hosted by Netlify - unlike Formspree, testing your form locally before committing to Netlify will not work.
+Step 1: Configure the `contactFormType` in the `config.toml`. Netlify does not require a `contactFormAction` configured.
+```toml
+[params]
+contactFormType = "netlify"
+```
+Step 2: Set `contact: true` or  `contact=true` in the frontmatter of a page. See `exampleSite/content/contact.html` as an example.
+Step 3: If you wish to use a Google reCaptcha v2, you must [go to a Google Admin console](https://www.google.com/recaptcha/about/) and create a reCaptcha.
+Make sure it is a reCaptcha v2. You must then [go to your Formspree account](https://help.formspree.io/hc/en-us/articles/360022811154-Adding-a-custom-reCAPTCHA-key) and enter the secret key that you were given in the appropriate location.
+Step 4: Enter the recaptcha site key in `config.toml`:
+```toml
+[params]
+contactFormReCaptchaSiteKey = "your-site-key"
+```
+Step 5: [Go to your Netlify account](https://www.netlify.com/blog/2018/05/23/bring-your-own-recaptcha-to-netlify-forms/) and let them know both the site key and the secret key for your custom recaptcha.
+Step 6: You will probably want to set up some [form notification](https://docs.netlify.com/forms/notifications/).
+
 ### Twitter Cards support
 
 In order to use the full functionality of Twitter cards, you will have to define a couple of settings in the `config.toml` and the frontmatter of a page.

--- a/README.md
+++ b/README.md
@@ -129,6 +129,10 @@ You can easily disable the animations from the `config.toml`. All you have to do
 [params]
 doNotLoadAnimations = true # Animations are loaded by default
 ```
+You can also turn off animations on a per-page basis by setting `animation` to `false` in the frontmatter of a page.
+```md
+animation: false
+```
 
 ### Control the date Format
 You can change the default date formating for the `list.html`, the `single.html` and the `index.html`. Simply configure the matching parameters.
@@ -267,9 +271,15 @@ use = "katex"  # options: "katex", "mathjax". default is "katex".
 Step 1: Configure the `contactFormAction` in the `config.toml`
 ```toml
 [params]
-#contactFormAction = "https://formspree.io/f/your-form-hash-here"
+contactFormAction = "https://formspree.io/f/your-form-hash-here"
 ```
 Step 2: Activate the `contact: true` or  `contact=true` in the frontmatter of a page. See `exampleSite/content/contact.html` as an example.
+Step 3: If you have configured a Google reCaptcha v2 in your formSpree form, you will want to
+put the site key in `config.toml`:
+```toml
+[params]
+contactFormReCaptchaSiteKey = "your-site-key"
+```
 ### Twitter Cards support
 
 In order to use the full functionality of Twitter cards, you will have to define a couple of settings in the `config.toml` and the frontmatter of a page.

--- a/README.md
+++ b/README.md
@@ -129,11 +129,6 @@ You can easily disable the animations from the `config.toml`. All you have to do
 [params]
 doNotLoadAnimations = true # Animations are loaded by default
 ```
-You can also turn off animations on a per-page basis by setting `animation` to `false` in the frontmatter of a page.
-```md
-animation: false
-```
-
 ### Control the date Format
 You can change the default date formating for the `list.html`, the `single.html` and the `index.html`. Simply configure the matching parameters.
 ```toml

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1115,4 +1115,4 @@ print {
 .form-feedback[feedback-success="false"] {
     color: var(--error-color);
 }
-/* (CONTACT) FORM END */[
+/* (CONTACT) FORM END */

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -132,40 +132,48 @@ a:active {
 
 @-webkit-keyframes fadeInDown {
     0% {
+        opacity: 0;
         -webkit-transform: translateY(-20px);
     }
 
     100% {
+        opacity: 1;
         -webkit-transform: translateY(0);
     }
 }
 
 @-moz-keyframes fadeInDown {
     0% {
+        opacity: 0;
         -moz-transform: translateY(-20px);
     }
 
     100% {
+        opacity: 1;
         -moz-transform: translateY(0);
     }
 }
 
 @-o-keyframes fadeInDown {
     0% {
+        opacity: 0;
         -o-transform: translateY(-20px);
     }
 
     100% {
+        opacity: 1;
         -o-transform: translateY(0);
     }
 }
 
 @keyframes fadeInDown {
     0% {
+        opacity: 0;
         transform: translateY(-20px);
     }
 
     100% {
+        opacity: 1;
         transform: translateY(0);
     }
 }

--- a/i18n/de.toml
+++ b/i18n/de.toml
@@ -20,5 +20,32 @@ other = "Du kannst hier zurück zur <a href=\"{{ . }}\">Startseite</a>."
 [comments]
 other = "Kommentare"
 
+[name]
+other = "Name"
+
+[name_error]
+other = "Please provide your name"
+
+[email]
+other = "Email"
+
+[email_error]
+other = "Please enter a valid email address"
+
+[message]
+other = "Message"
+
+[message_error]
+other = "Please let us know why you are contacting us"
+
 [send]
 other = "Senden"
+
+[form_captcha_error]
+other = "Captcha error; please try again later"
+
+[form_submit_error]
+other = "Fatal error, contact not made - please reach out some other way"
+
+[form_success]
+other = "Thank you for reaching out! We will be touch soon"

--- a/i18n/de.toml
+++ b/i18n/de.toml
@@ -44,7 +44,7 @@ other = "Senden"
 [form_captcha_error]
 other = "Captcha error; please try again later"
 
-[form_submit_error]
+[form_error]
 other = "Fatal error, contact not made - please reach out some other way"
 
 [form_success]

--- a/i18n/de.toml
+++ b/i18n/de.toml
@@ -24,28 +24,28 @@ other = "Kommentare"
 other = "Name"
 
 [name_error]
-other = "Please provide your name"
+other = "Bitte geben Sie Ihren Namen an"
 
 [email]
 other = "Email"
 
 [email_error]
-other = "Please enter a valid email address"
+other = "Bitte geben Sie eine gültige E-Mail Adresse ein"
 
 [message]
-other = "Message"
+other = "Nachricht"
 
 [message_error]
-other = "Please let us know why you are contacting us"
+other = "Bitte teilen Sie uns mit, warum Sie sich an uns wenden"
 
 [send]
 other = "Senden"
 
 [form_captcha_error]
-other = "Captcha error; please try again later"
+other = "Captcha-Fehler; bitte versuchen Sie es später noch einmal"
 
 [form_error]
-other = "Fatal error, contact not made - please reach out some other way"
+other = "Fataler Fehler, Kontakt nicht hergestellt - bitte melden Sie sich auf anderem Wege"
 
 [form_success]
-other = "Thank you for reaching out! We will be touch soon"
+other = "Thank für Ihre Kontaktaufnahme. Wir werden uns bald bei Ihnen melden."

--- a/i18n/dk.toml
+++ b/i18n/dk.toml
@@ -20,5 +20,32 @@ other = "Returner til <a href=\"{{ . }}\">homepage</a>."
 [comments]
 other = "kommentar"
 
+[name]
+other = "Name"
+
+[name_error]
+other = "Please provide your name"
+
+[email]
+other = "Email"
+
+[email_error]
+other = "Please enter a valid email address"
+
+[message]
+other = "Message"
+
+[message_error]
+other = "Please let us know why you are contacting us"
+
 [send]
 other = "Sende"
+
+[form_captcha_error]
+other = "Captcha error; please try again later"
+
+[form_submit_error]
+other = "Fatal error, contact not made - please reach out some other way"
+
+[form_success]
+other = "Thank you for reaching out! We will be touch soon"

--- a/i18n/dk.toml
+++ b/i18n/dk.toml
@@ -44,7 +44,7 @@ other = "Sende"
 [form_captcha_error]
 other = "Captcha error; please try again later"
 
-[form_submit_error]
+[form_error]
 other = "Fatal error, contact not made - please reach out some other way"
 
 [form_success]

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -44,7 +44,7 @@ other = "Send"
 [form_captcha_error]
 other = "Captcha error; please try again later"
 
-[form_submit_error]
+[form_error]
 other = "Fatal error, contact not made - please reach out in some other way"
 
 [form_success]

--- a/i18n/es.toml
+++ b/i18n/es.toml
@@ -21,31 +21,31 @@ other = "Puedes regresar a la <a href=\"{{ . }}\">página inicial</a>."
 other = "comentarios"
 
 [name]
-other = "Name"
+other = "Nombre"
 
 [name_error]
-other = "Please provide your name"
+other = "Por favor, indique su nombre"
 
 [email]
 other = "Email"
 
 [email_error]
-other = "Please enter a valid email address"
+other = "Por favor, introduzca una dirección de correo electrónico válida"
 
 [message]
-other = "Message"
+other = "Mensaje"
 
 [message_error]
-other = "Please let us know why you are contacting us"
+other = "Por favor, háganos saber por qué está contactando con nosotros"
 
 [send]
 other = "Enviar"
 
 [form_captcha_error]
-other = "Captcha error; please try again later"
+other = "Error de Captcha; por favor, inténtelo de nuevo más tarde"
 
 [form_error]
-other = "Fatal error, contact not made - please reach out some other way"
+other = "Error fatal, contacto no realizado - por favor, contacte de otra manera"
 
 [form_success]
-other = "Thank you for reaching out! We will be touch soon"
+other = "¡Gracias por tender la mano! Pronto nos tocará"

--- a/i18n/es.toml
+++ b/i18n/es.toml
@@ -20,5 +20,32 @@ other = "Puedes regresar a la <a href=\"{{ . }}\">página inicial</a>."
 [comments]
 other = "comentarios"
 
+[name]
+other = "Name"
+
+[name_error]
+other = "Please provide your name"
+
+[email]
+other = "Email"
+
+[email_error]
+other = "Please enter a valid email address"
+
+[message]
+other = "Message"
+
+[message_error]
+other = "Please let us know why you are contacting us"
+
 [send]
 other = "Enviar"
+
+[form_captcha_error]
+other = "Captcha error; please try again later"
+
+[form_submit_error]
+other = "Fatal error, contact not made - please reach out some other way"
+
+[form_success]
+other = "Thank you for reaching out! We will be touch soon"

--- a/i18n/es.toml
+++ b/i18n/es.toml
@@ -44,7 +44,7 @@ other = "Enviar"
 [form_captcha_error]
 other = "Captcha error; please try again later"
 
-[form_submit_error]
+[form_error]
 other = "Fatal error, contact not made - please reach out some other way"
 
 [form_success]

--- a/i18n/fa.toml
+++ b/i18n/fa.toml
@@ -44,7 +44,7 @@ other = "ارسال"
 [form_captcha_error]
 other = "Captcha error; please try again later"
 
-[form_submit_error]
+[form_error]
 other = "Fatal error, contact not made - please reach out some other way"
 
 [form_success]

--- a/i18n/fa.toml
+++ b/i18n/fa.toml
@@ -20,5 +20,32 @@ other = "شما می‌توانید برگردید به <a href=\"{{ . }}\">صف
 [comments]
 other = "نظرات"
 
+[name]
+other = "Name"
+
+[name_error]
+other = "Please provide your name"
+
+[email]
+other = "Email"
+
+[email_error]
+other = "Please enter a valid email address"
+
+[message]
+other = "Message"
+
+[message_error]
+other = "Please let us know why you are contacting us"
+
 [send]
 other = "ارسال"
+
+[form_captcha_error]
+other = "Captcha error; please try again later"
+
+[form_submit_error]
+other = "Fatal error, contact not made - please reach out some other way"
+
+[form_success]
+other = "Thank you for reaching out! We will be touch soon"

--- a/i18n/fi.toml
+++ b/i18n/fi.toml
@@ -44,7 +44,7 @@ other = "Lähetä"
 [form_captcha_error]
 other = "Captcha error; please try again later"
 
-[form_submit_error]
+[form_error]
 other = "Fatal error, contact not made - please reach out some other way"
 
 [form_success]

--- a/i18n/fi.toml
+++ b/i18n/fi.toml
@@ -20,5 +20,32 @@ other = "Voit palata takaisin <a href=\"{{ . }}\">kotisivulle</a>."
 [comments]
 other = "kommentit"
 
+[name]
+other = "Name"
+
+[name_error]
+other = "Please provide your name"
+
+[email]
+other = "Email"
+
+[email_error]
+other = "Please enter a valid email address"
+
+[message]
+other = "Message"
+
+[message_error]
+other = "Please let us know why you are contacting us"
+
 [send]
 other = "Lähetä"
+
+[form_captcha_error]
+other = "Captcha error; please try again later"
+
+[form_submit_error]
+other = "Fatal error, contact not made - please reach out some other way"
+
+[form_success]
+other = "Thank you for reaching out! We will be touch soon"

--- a/i18n/fr.toml
+++ b/i18n/fr.toml
@@ -21,31 +21,31 @@ other = "Vous pouvez revenir à <a href=\"{{ . }}\">l'accueil</a>."
 other = "commentaire"
 
 [name]
-other = "Name"
+other = "Nom"
 
 [name_error]
-other = "Please provide your name"
+other = "Veuillez indiquer votre nom"
 
 [email]
 other = "Email"
 
 [email_error]
-other = "Please enter a valid email address"
+other = Veuillez saisir une adresse électronique valide"
 
 [message]
 other = "Message"
 
 [message_error]
-other = "Please let us know why you are contacting us"
+other = "Veuillez nous indiquer la raison pour laquelle vous nous contactez"
 
 [send]
 other = "Envoyer"
 
 [form_captcha_error]
-other = "Captcha error; please try again later"
+other = Erreur Captcha ; veuillez réessayer plus tard"
 
 [form_error]
-other = "Fatal error, contact not made - please reach out some other way"
+other = "Erreur fatale, contact non établi - veuillez prendre contact d'une autre manière"
 
 [form_success]
-other = "Thank you for reaching out! We will be touch soon"
+other = "Merci de nous avoir contactés ! Nous vous contacterons bientôt"

--- a/i18n/fr.toml
+++ b/i18n/fr.toml
@@ -44,7 +44,7 @@ other = "Envoyer"
 [form_captcha_error]
 other = "Captcha error; please try again later"
 
-[form_submit_error]
+[form_error]
 other = "Fatal error, contact not made - please reach out some other way"
 
 [form_success]

--- a/i18n/fr.toml
+++ b/i18n/fr.toml
@@ -20,5 +20,32 @@ other = "Vous pouvez revenir à <a href=\"{{ . }}\">l'accueil</a>."
 [comments]
 other = "commentaire"
 
+[name]
+other = "Name"
+
+[name_error]
+other = "Please provide your name"
+
+[email]
+other = "Email"
+
+[email_error]
+other = "Please enter a valid email address"
+
+[message]
+other = "Message"
+
+[message_error]
+other = "Please let us know why you are contacting us"
+
 [send]
 other = "Envoyer"
+
+[form_captcha_error]
+other = "Captcha error; please try again later"
+
+[form_submit_error]
+other = "Fatal error, contact not made - please reach out some other way"
+
+[form_success]
+other = "Thank you for reaching out! We will be touch soon"

--- a/i18n/fr.toml
+++ b/i18n/fr.toml
@@ -30,7 +30,7 @@ other = "Veuillez indiquer votre nom"
 other = "Email"
 
 [email_error]
-other = Veuillez saisir une adresse électronique valide"
+other = "Veuillez saisir une adresse électronique valide"
 
 [message]
 other = "Message"
@@ -42,7 +42,7 @@ other = "Veuillez nous indiquer la raison pour laquelle vous nous contactez"
 other = "Envoyer"
 
 [form_captcha_error]
-other = Erreur Captcha ; veuillez réessayer plus tard"
+other = "Erreur Captcha ; veuillez réessayer plus tard"
 
 [form_error]
 other = "Erreur fatale, contact non établi - veuillez prendre contact d'une autre manière"

--- a/i18n/it.toml
+++ b/i18n/it.toml
@@ -20,5 +20,32 @@ other = "Puoi tornare alla <a href=\"{{ . }}\">homepage</a>."
 [comments]
 other = "commenti"
 
+[name]
+other = "Name"
+
+[name_error]
+other = "Please provide your name"
+
+[email]
+other = "Email"
+
+[email_error]
+other = "Please enter a valid email address"
+
+[message]
+other = "Message"
+
+[message_error]
+other = "Please let us know why you are contacting us"
+
 [send]
 other = "Spedire"
+
+[form_captcha_error]
+other = "Captcha error; please try again later"
+
+[form_submit_error]
+other = "Fatal error, contact not made - please reach out some other way"
+
+[form_success]
+other = "Thank you for reaching out! We will be touch soon"

--- a/i18n/it.toml
+++ b/i18n/it.toml
@@ -21,31 +21,31 @@ other = "Puoi tornare alla <a href=\"{{ . }}\">homepage</a>."
 other = "commenti"
 
 [name]
-other = "Name"
+other = "Nome"
 
 [name_error]
-other = "Please provide your name"
+other = "Si prega di fornire il proprio nome"
 
 [email]
-other = "Email"
+other = "e-mail"
 
 [email_error]
-other = "Please enter a valid email address"
+other = "Inserire un indirizzo e-mail valido"
 
 [message]
-other = "Message"
+other = "Messaggio"
 
 [message_error]
-other = "Please let us know why you are contacting us"
+other = "Per favore, fateci sapere perché ci contattate"
 
 [send]
 other = "Spedire"
 
 [form_captcha_error]
-other = "Captcha error; please try again later"
+other = "Errore Captcha; si prega di riprovare più tardi"
 
 [form_error]
-other = "Fatal error, contact not made - please reach out some other way"
+other = "Errore fatale, contatto non effettuato - si prega di contattare in altro modo"
 
 [form_success]
-other = "Thank you for reaching out! We will be touch soon"
+other = "Grazie per averci raggiunto! Ci sentiremo presto"

--- a/i18n/it.toml
+++ b/i18n/it.toml
@@ -44,7 +44,7 @@ other = "Spedire"
 [form_captcha_error]
 other = "Captcha error; please try again later"
 
-[form_submit_error]
+[form_error]
 other = "Fatal error, contact not made - please reach out some other way"
 
 [form_success]

--- a/i18n/pt-br.toml
+++ b/i18n/pt-br.toml
@@ -21,31 +21,31 @@ other = "Retornar à <a href=\"{{ . }}\">página inicial</a>."
 other = "comentários"
 
 [name]
-other = "Name"
+other = "Nome"
 
 [name_error]
-other = "Please provide your name"
+other = "Por favor, forneça seu nome"
 
 [email]
 other = "Email"
 
 [email_error]
-other = "Please enter a valid email address"
+other = "Por favor, digite um endereço de e-mail válido"
 
 [message]
-other = "Message"
+other = "Mensagem"
 
 [message_error]
-other = "Please let us know why you are contacting us"
+other = "Por favor nos informe por que você está entrando em contato conosco"
 
 [send]
 other = "Enviar"
 
 [form_captcha_error]
-other = "Captcha error; please try again later"
+other = "Captcha error; por favor, tente novamente mais tarde"
 
 [form_error]
-other = "Fatal error, contact not made - please reach out some other way"
+other = "Erro fatal, contato não feito - por favor, procure de outra forma"
 
 [form_success]
-other = "Thank you for reaching out! We will be touch soon"
+other = "Obrigado por estender a mão! Em breve estaremos em contato"

--- a/i18n/pt-br.toml
+++ b/i18n/pt-br.toml
@@ -20,5 +20,32 @@ other = "Retornar à <a href=\"{{ . }}\">página inicial</a>."
 [comments]
 other = "comentários"
 
+[name]
+other = "Name"
+
+[name_error]
+other = "Please provide your name"
+
+[email]
+other = "Email"
+
+[email_error]
+other = "Please enter a valid email address"
+
+[message]
+other = "Message"
+
+[message_error]
+other = "Please let us know why you are contacting us"
+
 [send]
 other = "Enviar"
+
+[form_captcha_error]
+other = "Captcha error; please try again later"
+
+[form_submit_error]
+other = "Fatal error, contact not made - please reach out some other way"
+
+[form_success]
+other = "Thank you for reaching out! We will be touch soon"

--- a/i18n/pt-br.toml
+++ b/i18n/pt-br.toml
@@ -44,7 +44,7 @@ other = "Enviar"
 [form_captcha_error]
 other = "Captcha error; please try again later"
 
-[form_submit_error]
+[form_error]
 other = "Fatal error, contact not made - please reach out some other way"
 
 [form_success]

--- a/i18n/zh-cn.toml
+++ b/i18n/zh-cn.toml
@@ -21,31 +21,31 @@ other = "返回<a href=\"{{ . }}\">首页</a>."
 other = "评论"
 
 [name]
-other = "Name"
+other = "名称"
 
 [name_error]
-other = "Please provide your name"
+other = "请提供您的姓名"
 
 [email]
-other = "Email"
+other = "电子邮件"
 
 [email_error]
-other = "Please enter a valid email address"
+other = "请输入有效的电子邮件地址"
 
 [message]
-other = "Message"
+other = "留言内容"
 
 [message_error]
-other = "Please let us know why you are contacting us"
+other = "请告诉我们您联系我们的原因。"
 
 [send]
 other = "发送"
 
 [form_captcha_error]
-other = "Captcha error; please try again later"
+other = "验证码错误，请稍后再试"
 
 [form_error]
-other = "Fatal error, contact not made - please reach out some other way"
+other = "致命的错误，没有取得联系--请以其他方式联系。"
 
 [form_success]
-other = "Thank you for reaching out! We will be touch soon"
+other = "谢谢您的联系！我们会尽快与您联系。我们会尽快联系您"

--- a/i18n/zh-cn.toml
+++ b/i18n/zh-cn.toml
@@ -44,7 +44,7 @@ other = "发送"
 [form_captcha_error]
 other = "Captcha error; please try again later"
 
-[form_submit_error]
+[form_error]
 other = "Fatal error, contact not made - please reach out some other way"
 
 [form_success]

--- a/i18n/zh-cn.toml
+++ b/i18n/zh-cn.toml
@@ -20,5 +20,32 @@ other = "返回<a href=\"{{ . }}\">首页</a>."
 [comments]
 other = "评论"
 
+[name]
+other = "Name"
+
+[name_error]
+other = "Please provide your name"
+
+[email]
+other = "Email"
+
+[email_error]
+other = "Please enter a valid email address"
+
+[message]
+other = "Message"
+
+[message_error]
+other = "Please let us know why you are contacting us"
+
 [send]
 other = "发送"
+
+[form_captcha_error]
+other = "Captcha error; please try again later"
+
+[form_submit_error]
+other = "Fatal error, contact not made - please reach out some other way"
+
+[form_success]
+other = "Thank you for reaching out! We will be touch soon"

--- a/i18n/zh-tw.toml
+++ b/i18n/zh-tw.toml
@@ -44,7 +44,7 @@ other = "發送"
 [form_captcha_error]
 other = "Captcha error; please try again later"
 
-[form_submit_error]
+[form_error]
 other = "Fatal error, contact not made - please reach out some other way"
 
 [form_success]

--- a/i18n/zh-tw.toml
+++ b/i18n/zh-tw.toml
@@ -20,5 +20,32 @@ other = "返回 <a href=\"{{ . }}\">首頁</a>."
 [comments]
 other = "註解"
 
+[name]
+other = "Name"
+
+[name_error]
+other = "Please provide your name"
+
+[email]
+other = "Email"
+
+[email_error]
+other = "Please enter a valid email address"
+
+[message]
+other = "Message"
+
+[message_error]
+other = "Please let us know why you are contacting us"
+
 [send]
 other = "發送"
+
+[form_captcha_error]
+other = "Captcha error; please try again later"
+
+[form_submit_error]
+other = "Fatal error, contact not made - please reach out some other way"
+
+[form_success]
+other = "Thank you for reaching out! We will be touch soon"

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,5 +1,5 @@
 {{ define "main" }}
-    <div class="archive {{ with .Site.Params.doNotLoadAnimations }} . {{ else }} animated fadeInDown {{ end }}">
+    <div class="archive {{ if and (or (not (isset .Site.Params "doNotLoadAnimations")) (and (isset .Site.Params "doNotLoadAnimations") (not .Site.Params.doNotLoadAnimations))) (or (not (isset .Page.Params "animation")) .Page.Params.animation) }} animated fadeInDown {{ end }}">
         <ul class="list-with-title">
             {{ range .Data.Pages.GroupByDate "2006" }}
                 <div class="listing-title">{{ .Key }}</div>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,5 +1,5 @@
 {{ define "main" }}
-    <div class="post {{ with .Site.Params.doNotLoadAnimations }} . {{ else }} animated fadeInDown {{ end }}">
+    <div class="post {{ if and (or (not (isset .Site.Params "doNotLoadAnimations")) (and (isset .Site.Params "doNotLoadAnimations") (not .Site.Params.doNotLoadAnimations))) (or (not (isset .Page.Params "animation")) .Page.Params.animation) }} animated fadeInDown {{ end }}">
         <div class="post-content">
             {{ if .Params.thumbnail }}
             <img class="post-thumbnail" src="{{ .Params.thumbnail | absURL }}" alt="Thumbnail image">

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,6 +1,6 @@
 {{ define "main" }}
 
-    <div class="post {{ with .Site.Params.doNotLoadAnimations }} . {{ else }} animated fadeInDown {{ end }}">
+    <div class="post {{ if and (or (not (isset .Site.Params "doNotLoadAnimations")) (and (isset .Site.Params "doNotLoadAnimations") (not .Site.Params.doNotLoadAnimations))) (or (not (isset .Page.Params "animation")) .Page.Params.animation) }} animated fadeInDown {{ end }}">
         <!-- (Optional) Home
             -- on top of `mainSections` content (aka posts) ;
             -- as declared in content/_index.md
@@ -13,7 +13,7 @@
     {{ $paginator := .Paginate (where .Site.RegularPages "Type" "in" .Site.Params.mainSections) }}
     {{ range $paginator.Pages }}
 
-        <div class="post {{ with .Site.Params.doNotLoadAnimations }} . {{ else }} animated fadeInDown {{ end }}">
+        <div class="post {{ if and (or (not (isset .Site.Params "doNotLoadAnimations")) (and (isset .Site.Params "doNotLoadAnimations") (not .Site.Params.doNotLoadAnimations))) (or (not (isset .Page.Params "animation")) .Page.Params.animation) }} animated fadeInDown {{ end }}">
             {{ if .Params.thumbnail }}
             <div class="post-thumbnail">
                 <a href="{{ .RelPermalink }}">

--- a/layouts/partials/contact.html
+++ b/layouts/partials/contact.html
@@ -2,7 +2,7 @@
 <script type="text/javascript" src="{{ $jquery.Permalink }}"></script>
 
 <div class="contact-form">
-  <form id="contact-form" name="Contact Form" class="form-style" method="POST" action="{{ if eq .Site.Params.ContactFormType "netlify" }}/{{ else }}{{ .Site.Params.contactFormAction }}{{ end }}"
+  <form id="contact-form" name="Contact Form" class="form-style" method="POST" action="{{ .Site.Params.contactFormAction }}"
     {{ with .Site.Params.contactFormReCaptchaSiteKey }} data-netlify-recaptcha="true"{{ end }}
     {{ if eq .Site.Params.contactFormType "netlify" }} data-netlify="true" netlify-honeypot="my-lovely-house"{{ end }}>
     <ul>
@@ -22,8 +22,10 @@
         <div class="form-feedback" id="submit-feedback"></div>
       </li>
       {{ if eq .Site.Params.contactFormType "netlify"}}
+      <li>
         <input name="form-name" value="Contact Form" type="hidden">
         <input class="field-style" name="my-lovely-house" id="my-lovely-house" type="hidden">
+      </li>
       {{ end }}
       {{ with .Site.Params.contactFormReCaptchaSiteKey }}
       <li>
@@ -51,18 +53,17 @@
       setFeedback('{{ i18n "form_captcha_error" }}', false);
     } else {
       // Formspree requires json; ajax will do the conversion.
-      const form = $('#contact-form');
-      const message = form.serialize();
-      const dataType = ('{{ .Site.Params.ContactFormType }}' === 'netlify')
-        ? 'application/x-www-form-urlencoded' : 'json';
+      const message = $('#contact-form').serialize();
+      const specifics = ('{{ .Site.Params.ContactFormType }}' === 'netlify')
+        ? { url: '/', dataType: 'application/x-www-form-urlencoded' }
+        : { url: '{{ .Site.Params.contactFormAction }}', dataType: 'json'};
 
-      alert(`url: ${form.prop('action')}, datatype: ${datatype}, message: ${JSON.stringify(message, null, 2)}.`);
+      alert(`Specifics: ${JSON.stringify(specifics, null, 2)}. Message: ${JSON.stringify(message, null, 2)}.`);
 
       $.ajax({
-          url: form.prop('action'),
+          ...specifics,
           method: 'POST',
           data: message,
-          dataType,
           success: (result) => {
             alert(result);
             setFeedback('{{ i18n "form_success" }}');
@@ -88,7 +89,6 @@
   
     // Make sure we have a captcha to execute before trying to do so.
     if ($('.g-recaptcha')[0] !== null) {
-      alert('grecaptcha.execute()');
       grecaptcha.execute();
     } else {
       onSubmit();

--- a/layouts/partials/contact.html
+++ b/layouts/partials/contact.html
@@ -55,7 +55,7 @@
       // Formspree requires json; ajax will do the conversion.
       const message = $('#contact-form').serialize();
       const specifics = ('{{ .Site.Params.ContactFormType }}' === 'netlify')
-        ? { url: window.location.href, dataType: 'application/x-www-form-urlencoded' }
+        ? { url: '/', dataType: 'application/x-www-form-urlencoded' }
         : { url: '{{ .Site.Params.contactFormAction }}', dataType: 'json'};
 
       alert(`Specifics: ${JSON.stringify(specifics, null, 2)}. Message: ${JSON.stringify(message, null, 2)}.`);

--- a/layouts/partials/contact.html
+++ b/layouts/partials/contact.html
@@ -56,26 +56,15 @@
       const dataType = ('{{ .Site.Params.ContactFormType }}' === 'netlify')
         ? 'application/x-www-form-urlencoded' : 'json';
 
-      const temp = {
-        url: form.prop('action'),
-        method: 'POST',
-        data: message,
-        dataType,
-      };
-
-      alert(`ajax data: ${JSON.stringify(temp, null, 2)}`);
-
       $.ajax({
           url: form.prop('action'),
           method: 'POST',
           data: message,
           dataType,
           success: (result) => {
-            alert(JSON.stringify(result));
             setFeedback('{{ i18n "form_success" }}');
           },
           error: (xhr) => {
-            alert(`${xhr.status}, ${xhr.responseText}`);
             setFeedback('{{ i18n "form_submit_error" }}', false);
           },
       });

--- a/layouts/partials/contact.html
+++ b/layouts/partials/contact.html
@@ -29,7 +29,7 @@
       {{ end }}
       {{ with .Site.Params.contactFormReCaptchaSiteKey }}
       <li>
-        <div id="g-recaptcha" data-netlify-recaptcha="true"></div>
+        <div id="g-recaptcha"></div>
       </li>
       {{ end }}
     </ul>
@@ -58,7 +58,7 @@
         ? { url: window.location.href, dataType: 'application/x-www-form-urlencoded' }
         : { url: '{{ .Site.Params.contactFormAction }}', dataType: 'json'};
 
-      // alert(`Specifics: ${JSON.stringify(specifics, null, 2)}. Message: ${JSON.stringify(message, null, 2)}.`);
+      alert(`Specifics: ${JSON.stringify(specifics, null, 2)}. Message: ${JSON.stringify(message, null, 2)}.`);
 
       $.ajax({
           ...specifics,

--- a/layouts/partials/contact.html
+++ b/layouts/partials/contact.html
@@ -16,15 +16,17 @@
       <li>
         <input class="field-style" id="form-submit" type="submit" value="{{ i18n "send" }}">
       </li>
+      {{ with .Site.Params.contactFormReCaptchaSiteKey }}
+      <li>
+        <div id="g-recaptcha"></div>
+      </li>
+      {{ end }}
       <li>
         <div id="submit-feedback"></div>
       </li>
     </ul>
   </form>
 </div>
-{{ with .Site.Params.contactFormReCaptchaSiteKey }}
-  <div id="g-recaptcha"></div>
-{{ end }}
 
 <script>
   // Sets feedback message.

--- a/layouts/partials/contact.html
+++ b/layouts/partials/contact.html
@@ -22,10 +22,8 @@
         <div class="form-feedback" id="submit-feedback"></div>
       </li>
       {{ if eq .Site.Params.contactFormType "netlify"}}
-      <li>
         <input name="form-name" value="Contact Form" type="hidden">
         <input class="field-style" name="my-lovely-house" id="my-lovely-house" type="hidden">
-      </li>
       {{ end }}
       {{ with .Site.Params.contactFormReCaptchaSiteKey }}
       <li>

--- a/layouts/partials/contact.html
+++ b/layouts/partials/contact.html
@@ -2,7 +2,7 @@
 <script type="text/javascript" src="{{ $jquery.Permalink }}"></script>
 
 <div class="contact-form">
-  <form id="contact-form" name="Contact Form" class="form-style" method="POST" action="{{ .Site.Params.contactFormAction }}"
+  <form id="contact-form" name="Contact Form" class="form-style" method="POST" action="{{ if eq .Site.Params.contactFormType "netlify" }}/{{ else }}{{ .Site.Params.contactFormAction }}{{ end }}"
     {{ with .Site.Params.contactFormReCaptchaSiteKey }} data-netlify-recaptcha="true"{{ end }}
     {{ if eq .Site.Params.contactFormType "netlify" }} data-netlify="true" netlify-honeypot="my-lovely-house"{{ end }}>
     <ul>
@@ -51,23 +51,31 @@
       setFeedback('{{ i18n "form_captcha_error" }}', false);
     } else {
       // Formspree requires json; ajax will do the conversion.
-      const message = $('#contact-form').serialize();
-      const specifics = ('{{ .Site.Params.ContactFormType }}' === 'netlify')
-        ? { url: '/', dataType: 'application/x-www-form-urlencoded' }
-        : { url: '{{ .Site.Params.contactFormAction }}', dataType: 'json'};
+      const form = $('#contact-form');
+      const message = form.serialize();
+      const dataType = ('{{ .Site.Params.ContactFormType }}' === 'netlify')
+        ? 'application/x-www-form-urlencoded' : 'json';
 
-      alert(`Specifics: ${JSON.stringify(specifics, null, 2)}. Message: ${JSON.stringify(message, null, 2)}.`);
+      const temp = {
+        url: form.prop('action'),
+        method: 'POST',
+        data: message,
+        dataType,
+      };
+
+      alert(`ajax data: ${JSON.stringify(temp, null, 2)}`);
 
       $.ajax({
-          ...specifics,
+          url: form.prop('action'),
           method: 'POST',
           data: message,
+          dataType,
           success: (result) => {
-            alert(result);
+            alert(JSON.stringify(result));
             setFeedback('{{ i18n "form_success" }}');
           },
           error: (xhr) => {
-            alert(xhr.status);
+            alert(`${xhr.status}, ${xhr.responseText}`);
             setFeedback('{{ i18n "form_submit_error" }}', false);
           },
       });

--- a/layouts/partials/contact.html
+++ b/layouts/partials/contact.html
@@ -65,9 +65,11 @@
           method: 'POST',
           data: message,
           success: (result) => {
+            alert(result);
             setFeedback('{{ i18n "form_success" }}');
           },
           error: (xhr) => {
+            alert(xhr.status);
             setFeedback('{{ i18n "form_submit_error" }}', false);
           },
       });

--- a/layouts/partials/contact.html
+++ b/layouts/partials/contact.html
@@ -1,5 +1,5 @@
-<script src="https://www.google.com/recaptcha/api.js" async defer></script>
-<script type="text/javascript" src="http://code.jquery.com/jquery-3.5.1.min.js"></script>
+<script type="text/javascript" src="https://www.google.com/recaptcha/api.js" async defer></script>
+<script type="text/javascript" src="/assets/js/jquery.js"></script>
 
 <div class="contact-form">
   <form id="contact-form" class="form-style" method="POST" action="{{ .Site.Params.contactFormAction }}">

--- a/layouts/partials/contact.html
+++ b/layouts/partials/contact.html
@@ -2,7 +2,7 @@
 <script type="text/javascript" src="{{ $jquery.Permalink }}"></script>
 
 <div class="contact-form">
-  <form id="contact-form" name="Contact Form" class="form-style" method="POST" action="{{ .Site.Params.contactFormAction }}"
+  <form id="contact-form" name="Contact Form" class="form-style" method="POST" action="{{ if eq .Site.Params.ContactFormType "netlify" }}/{{ else }}{{ .Site.Params.contactFormAction }}{{ end }}"
     {{ with .Site.Params.contactFormReCaptchaSiteKey }} data-netlify-recaptcha="true"{{ end }}
     {{ if eq .Site.Params.contactFormType "netlify" }} data-netlify="true" netlify-honeypot="my-lovely-house"{{ end }}>
     <ul>
@@ -22,10 +22,8 @@
         <div class="form-feedback" id="submit-feedback"></div>
       </li>
       {{ if eq .Site.Params.contactFormType "netlify"}}
-      <li>
         <input name="form-name" value="Contact Form" type="hidden">
         <input class="field-style" name="my-lovely-house" id="my-lovely-house" type="hidden">
-      </li>
       {{ end }}
       {{ with .Site.Params.contactFormReCaptchaSiteKey }}
       <li>
@@ -53,17 +51,18 @@
       setFeedback('{{ i18n "form_captcha_error" }}', false);
     } else {
       // Formspree requires json; ajax will do the conversion.
-      const message = $('#contact-form').serialize();
-      const specifics = ('{{ .Site.Params.ContactFormType }}' === 'netlify')
-        ? { url: '/', dataType: 'application/x-www-form-urlencoded' }
-        : { url: '{{ .Site.Params.contactFormAction }}', dataType: 'json'};
+      const form = $('#contact-form');
+      const message = form.serialize();
+      const dataType = ('{{ .Site.Params.ContactFormType }}' === 'netlify')
+        ? 'application/x-www-form-urlencoded' : 'json';
 
-      alert(`Specifics: ${JSON.stringify(specifics, null, 2)}. Message: ${JSON.stringify(message, null, 2)}.`);
+      alert(`url: ${form.prop('action')}, datatype: ${datatype}, message: ${JSON.stringify(message, null, 2)}.`);
 
       $.ajax({
-          ...specifics,
+          url: form.prop('action'),
           method: 'POST',
           data: message,
+          dataType,
           success: (result) => {
             alert(result);
             setFeedback('{{ i18n "form_success" }}');
@@ -89,6 +88,7 @@
   
     // Make sure we have a captcha to execute before trying to do so.
     if ($('.g-recaptcha')[0] !== null) {
+      alert('grecaptcha.execute()');
       grecaptcha.execute();
     } else {
       onSubmit();

--- a/layouts/partials/contact.html
+++ b/layouts/partials/contact.html
@@ -21,7 +21,7 @@
       </li>
     </ul>
     {{ with .Site.Params.contactFormReCaptchaSiteKey }}
-      <div class="g-recaptcha" data-sitekey="{{ . }}" data-callback="onSubmit" data-size="invisible" data-theme=""></div>
+      <div class="g-recaptcha" data-sitekey="{{ . }}" data-callback="onSubmit" data-size="invisible" data-theme="{{ $.Page.Params.data-theme }}"></div>
     {{ end }}
   </form>
 </div>

--- a/layouts/partials/contact.html
+++ b/layouts/partials/contact.html
@@ -61,11 +61,16 @@
           method: 'POST',
           data: message,
           dataType,
-          success: (result) => {
-            setFeedback('{{ i18n "form_success" }}');
-          },
-          error: (xhr) => {
-            setFeedback('{{ i18n "form_submit_error" }}', false);
+          complete: (xhr, status) => {
+            // Netlify asks for urlencoded data but sends back HTML. This causes a
+            // data type mismatch that Ajax flags as an error ... I believe the solution is to just
+            // screen for the false negative in this combined handler.
+            // https://stackoverflow.com/questions/16230624/ajax-call-fires-error-event-but-returns-200-ok/16230794
+            if (status === 'error' && xhr.status !== 200) {
+              setFeedback('{{ i18n "form_error" }}', false);
+            } else {
+              setFeedback('{{ i18n "form_success" }}');
+            }
           },
       });
 

--- a/layouts/partials/contact.html
+++ b/layouts/partials/contact.html
@@ -21,7 +21,7 @@
       </li>
     </ul>
     {{ with .Site.Params.contactFormReCaptchaSiteKey }}
-      <div class="g-recaptcha" data-sitekey="{{ . }}" data-callback="onSubmit" data-size="invisible" data-theme="{{ $.Page.Params.data-theme }}"></div>
+      <div class="g-recaptcha" data-sitekey="{{ . }}" data-callback="onSubmit" data-size="invisible" data-theme=""></div>
     {{ end }}
   </form>
 </div>

--- a/layouts/partials/contact.html
+++ b/layouts/partials/contact.html
@@ -1,5 +1,5 @@
-<script type="text/javascript" src="https://www.google.com/recaptcha/api.js" async defer></script>
-<script type="text/javascript" src="/assets/js/jquery.js"></script>
+{{ $jquery := resources.Get "js/jquery.js" }}
+<script type="text/javascript" src="{{ $jquery.Permalink }}"></script>
 
 <div class="contact-form">
   <form id="contact-form" class="form-style" method="POST" action="{{ .Site.Params.contactFormAction }}">
@@ -20,11 +20,11 @@
         <div id="submit-feedback"></div>
       </li>
     </ul>
-    {{ with .Site.Params.contactFormReCaptchaSiteKey }}
-      <div class="g-recaptcha" data-sitekey="{{ . }}" data-callback="onSubmit" data-size="invisible" data-theme=""></div>
-    {{ end }}
   </form>
 </div>
+{{ with .Site.Params.contactFormReCaptchaSiteKey }}
+  <div id="g-recaptcha"></div>
+{{ end }}
 
 <script>
   // Sets feedback message.
@@ -78,3 +78,21 @@
     }
   });
 </script>
+
+{{ with .Site.Params.contactFormReCaptchaSiteKey }}
+  <script>
+      // Captcha rendered dynamically to deal with some rendering issues with
+      // theme and with animation.
+      function captchaLoadCallback() {
+        grecaptcha.render( 'g-recaptcha', {
+          sitekey: '{{ . }}',
+          callback: onSubmit,
+          size: 'invisible',
+          badge: 'bottomright',
+          theme: $('html').attr('data-theme'),
+        });
+      }
+  </script>
+  <!-- Explicit rendering of recaptcha to deal with data-theme and animation issues -->
+  <script type="text/javascript" src="https://www.google.com/recaptcha/api.js?onload=captchaLoadCallback&render=explicit" async defer></script>
+{{ end }}

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -1,4 +1,4 @@
-<div class="page-top {{ with .Site.Params.doNotLoadAnimations }} . {{ else }} animated fadeInDown {{ end }}">
+<div class="page-top {{ if and (or (not (isset .Site.Params "doNotLoadAnimations")) (and (isset .Site.Params "doNotLoadAnimations") (not .Site.Params.doNotLoadAnimations))) (or (not (isset .Page.Params "animation")) .Page.Params.animation) }} animated fadeInDown {{ end }}">
     <a role="button" class="navbar-burger" data-target="navMenu" aria-label="menu" aria-expanded="false">
         <span aria-hidden="true"></span>
         <span aria-hidden="true"></span>

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -1,4 +1,4 @@
-<div class="sidebar{{ with .Site.Params.doNotLoadAnimations }} . {{ else }} animated fadeInDown {{ end }}">
+<div class="sidebar{{ if and (or (not (isset .Site.Params "doNotLoadAnimations")) (and (isset .Site.Params "doNotLoadAnimations") (not .Site.Params.doNotLoadAnimations))) (or (not (isset .Page.Params "animation")) .Page.Params.animation) }} animated fadeInDown {{ end }}">
     <div class="logo-title">
         <div class="title">
             <img src="{{ .Site.Params.profilePicture | absURL }}" alt="profile picture">


### PR DESCRIPTION
OK both forms have been tested as working. Formspree has an optional recaptcha, Netlify has an optional recaptcha and a mandatory honeypot. I corrected css around the form inputs, reinstated the animation fade in. Formspree's redirections are no more, feedback provided at the bottom of the form. All text is internationalized. Recaptcha will reflect the theme of the website, but not if the theme switcher is used while the contact form is visible - it will show the change in the next refresh.