### PR TITLE
Fix punctuation color in the dark theme syntax highlighting.

### DIFF
--- a/assets/css/markupHighlight.css
+++ b/assets/css/markupHighlight.css
@@ -119,6 +119,7 @@ html[data-theme='dark'] {
   --chr-mo-color: #ae81ff;
   --chr-o-color: #f92672;
   --chr-ow-color: #f92672;
+  --chr-p-color: #f8f8f2;
   --chr-c-color: #75715e;
   --chr-ch-color: #75715e;
   --chr-cm-color: #75715e;


### PR DESCRIPTION
The `chr-p-color` value was missing from the dark theme section. As a result,
punctuation marks appeared unreadable when using the dark theme. According to
[Chroma's source](https://github.com/alecthomas/chroma/blob/master/styles/monokai.go),
the Monokai color for punctuation is `#f8f8f2`.