### PR TITLE
Added a configuration option for the medium zoom functionality.

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,6 +364,15 @@ Both approaches can even be mixed:
 customJs = ["https://cdn.exmple.org/fancyscript.js", "js/world.js"]
 ```
 
+### Medium Like Zoom
+
+Enabled by default, the medium like zoom for images can be disabled by adding the following config under `[params]`.
+
+```toml
+[params]
+enableMediumZoom = false
+```
+
 ### Content Security Policy
 
 The theme is compliant with most strict CSP policies out of the box. A sample CSP for an Anatole-based site would look something like this:

--- a/layouts/partials/medium-zoom.html
+++ b/layouts/partials/medium-zoom.html
@@ -1,6 +1,9 @@
+{{ $enableMediumZoom := default true (.Site.Params.enableMediumZoom) }}
+{{- if eq $enableMediumZoom true -}}
 {{ $js := resources.Get "js/medium-zoom.js" }}
 {{ $secureJS := $js |  resources.Minify | resources.Fingerprint }}
 <script type="text/javascript"
         src="{{ $secureJS.Permalink }}"
         integrity="{{ $secureJS.Data.Integrity }}"
         crossorigin="anonymous"></script>
+{{- end -}}


### PR DESCRIPTION
Hi,

I wanted a way of disabling the medium zoom functionality but I didn't see any way to do that. To do this I overrode the partial in my own project but thought it made sense to see if I could get this in the main theme.

I'm new to Hugo and this is my first time contributing to any project on GitHub so apologies if something is off.

Cheers.