### PR TITLE
Implemented per page comment disabling using the page Front Matter.

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,9 +231,16 @@ issueTerm = "pathname"
 theme= "preferred-color-scheme"
 # label = 
 ```
+
 Two notes on the security of Utteranc.es
 - If you are using a strict CSP, you'll have to add the domain to it. 
 - The script currently has no built-in integrity check, due to limitations of [Utterances](https://github.com/utterance/utterances/issues/40).
+
+### Disabling Comments Per Page
+
+Comments can be disabled per page by setting `disableComments: true` on the pages [Front Matter](https://gohugo.io/content-management/front-matter/)
+
+
 ### Google Analytics
 
 To use Google Analytics, a valid tracking code has to be added. If you don't want to load the code, then commend out the parameter.

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -33,7 +33,7 @@
             </div>
         </div>
 
-        {{ if eq .Type "post"}}
+        {{ if and (eq .Type "post") (ne .Page.Params.disableComments true) }}
             {{- if .Site.DisqusShortname -}}
                 <div id="fb_comments_container">
                     <h2>{{ i18n "comments" }}</h2>


### PR DESCRIPTION
Hi,

Another small config option allows the comments to be disabled on a page per page basis by including `disableComments: true` in the Front Matter of the page.

I noticed the `post.md` archetype in the theme has the `DisableComments: false` Front Matter but couldn't find any evidence of this being implemented in the past.

Cheers.