### PR TITLE
Change to meta description to use the pages description Front Matter

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -5,7 +5,7 @@
     <meta charset="utf-8">
     {{- hugo.Generator -}}
     <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
-    <meta name="description" content="{{ .Site.Params.description }}">
+    <meta name="description" content="{{ if .Params.description }}{{ .Params.description }}{{ else }}{{ .Site.Params.description }}{{ end }}">
     {{- if .Site.Params.googleSiteVerify }}
     <meta name="google-site-verification" content="{{ .Site.Params.googleSiteVerify }}">
     {{- end -}}


### PR DESCRIPTION
As Per: [Issue 153](https://github.com/lxndrblz/anatole/issues/153)

Change to meta description to use the page description Front Matter if set falling back to the site description if not.