### PR TITLE
Tweak to taxomony partials to reduce code duplication

### DIFF
--- a/layouts/partials/taxonomy/categories.html
+++ b/layouts/partials/taxonomy/categories.html
@@ -1,7 +1,1 @@
-<span class="separator">
-    {{- range $index, $el := . -}}
-        {{- $category := replace . "#" "%23" -}}
-        {{- $category = replace $category "." "%2e" -}}
-        <a class="category" href="{{ ( printf "categories/%s/" ( $category | urlize ) ) | relLangURL }}">{{ . }}</a>
-    {{- end -}}
-</span>
+{{ partial "taxonomy/template.html" (dict "items" . "linkClass" "category" "linkBase" "categories") }}

--- a/layouts/partials/taxonomy/tags.html
+++ b/layouts/partials/taxonomy/tags.html
@@ -1,7 +1,1 @@
-<span class="separator">
-    {{- range $index, $el := . -}}
-    {{- $tag := replace . "#" "%23" -}}
-    {{- $tag = replace $tag "." "%2e" -}}
-    <a class="tag" href="{{ ( printf "tags/%s/" ( $tag | urlize ) ) | relLangURL }}">{{- . -}}</a>
-    {{- end -}}
-</span>
+{{ partial "taxonomy/template.html" (dict "items" . "linkClass" "tag" "linkBase" "tags") }}

--- a/layouts/partials/taxonomy/template.html
+++ b/layouts/partials/taxonomy/template.html
@@ -1,0 +1,12 @@
+{{- $linkClass := .linkClass -}}
+{{- $linkBase := .linkBase -}}
+
+<span class="separator">
+    {{- range $index, $el := .items -}}
+        <!-- Replace certain special characters with their URL encoded counterparts -->
+        {{- $item := replace . "#" "%23" -}}
+        {{- $item = replace $item "." "%2e" -}}
+        {{- $link := ( printf "%s/%s/" $linkBase ( $item | urlize ) ) | relLangURL -}}
+        <a class="{{$linkClass}}" href="{{$link}}">{{- . -}}</a>
+    {{- end -}}
+</span>


### PR DESCRIPTION
Afternoon,

Feel free to do with this as you please I just noticed the partials were incredibly similar and since the URL encoding logic had been added to both they'd benefit from having a single common parameterised partial.

Cheers.