### PR TITLE
Use blog type as well as post type

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -6,7 +6,7 @@
             {{ end }}
             <div class="post-title">
                 <h3>{{ .Title }}</h3>
-                {{ if eq .Type "post"}}
+                {{ if or (eq .Type "post") (eq .Type "blog")}}
                     <div class="info">
                         <em class="fas fa-calendar-day"></em>
                         <span class="date">{{ if isset .Site.Params "singledateformat" }} 
@@ -33,7 +33,7 @@
             </div>
         </div>
 
-        {{ if and (eq .Type "post") (ne .Page.Params.disableComments true) }}
+        {{ if and (or (eq .Type "post") (eq .Type "blog")) (ne .Page.Params.disableComments true) }}
             {{- if .Site.DisqusShortname -}}
                 <div id="fb_comments_container">
                     <h2>{{ i18n "comments" }}</h2>


### PR DESCRIPTION
@lxndrblz not sure if this is the correct way of adding another type to be matched; I'm not really familiar w/ Go or Hugo code so please let me know if there is a different approach!

This change allows the comments and post read time to show up for posts that are under the `blog/` subdirectory.