### PR TITLE
Allow users to re-define post section name

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,16 @@ If you prefer having a static page as your home page rather than a listing of th
 ```
 Put any content into the `_index.md` file located in the content directory. If you want, you can also have some static text and the posts below. In such case, simply keep the `mainSections = ["post"]` and put any static content in the `_index.md`.
 
+### Rename post section
+If you want to have a different post section identifier, such as `/blog`, you can specify the section name using `postSectionName`:
+
+```toml
+[params]
+  postSectionName = "blog"
+```
+
+If the parameter is not set, it will default to `post`.
+
 ### Show full post content on the home page
 If you prefer the full content of your posts to appear on the home page rather than a summary of each post, then set the parameter `fullPostContent` to `true`.
 ```toml

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -44,7 +44,7 @@ doNotLoadAnimations = false
 # CommentoURL = "https://commento.example.com/js/commento.js"
 # Read More links for truncated summaries
 # readMore = true
-
+# postSectionName = "blog"
 
 [params.simpleAnalytics]
 # enable = true

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -6,7 +6,7 @@
             {{ end }}
             <div class="post-title">
                 <h3>{{ .Title }}</h3>
-                {{ if eq .Type "post"}}
+                {{ if or (eq .Type "post") (eq .Type .Site.Params.postSectionName) }}
                     <div class="info">
                         <em class="fas fa-calendar-day"></em>
                         <span class="date">{{ if isset .Site.Params "singledateformat" }} 
@@ -33,7 +33,7 @@
             </div>
         </div>
 
-        {{ if and (eq .Type "post") (ne .Page.Params.disableComments true) }}
+        {{ if and (or (eq .Type "post") (eq .Type .Site.Params.postSectionName)) (ne .Page.Params.disableComments true) }}
             {{- if .Site.DisqusShortname -}}
                 <div id="fb_comments_container">
                     <h2>{{ i18n "comments" }}</h2>


### PR DESCRIPTION
This kind of works, but I'm not sure if I need to check for the parameter before comparing it to .Type, like this:

    if isset .Site.Params "postSectionName"

Adding it to the if statement returns false for some reason, so I removed it and it still works. Apparently if `postSectionName` isn't defined then the following statement will return false anyway:

    if eq .Site.Params.postSectionName .Type

May need more checks as I'm not very good w/ Go/Hugo code.