### PR TITLE
Change how the copyright string is constructed

### DIFF
--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -18,6 +18,6 @@
         {{ end }}
     </ul>
     <div class="footer">
-        <div class="by_farbox">&copy; {{ .Site.Params.author }} {{ if isset .Site.Params "copyright" }} {{ .Site.Params.copyright }} {{ else }} {{ now.Format "2006"}} {{end}}</div>
+        <div class="by_farbox">&copy; {{ if isset .Site.Params "copyright" }} {{ .Site.Params.copyright }} {{ else }} {{ .Site.Params.author }} {{ now.Format "2006"}} {{end}}</div>
     </div>
 </div>


### PR DESCRIPTION
 - If .Site.Params.copyright is set, treat it as markdown (links to a
   license or copyright info page are now possible).
 - Only if it's not set, show the author and the current year.