### PR TITLE
Treat the "copyright" parameter as markdown

### DIFF
--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -18,6 +18,6 @@
         {{ end }}
     </ul>
     <div class="footer">
-        <div class="by_farbox">&copy; {{ if isset .Site.Params "copyright" }} {{ .Site.Params.copyright }} {{ else }} {{ .Site.Params.author }} {{ now.Format "2006"}} {{end}}</div>
+        <div class="by_farbox">&copy; {{ if isset .Site.Params "copyright" }} {{ .Site.Params.copyright | markdownify }} {{ else }} {{ .Site.Params.author }} {{ now.Format "2006"}} {{end}}</div>
     </div>
 </div>


### PR DESCRIPTION
Actually do so this time.

Turns out, I forgot to pipe `.Site.Params.copyright` to `markdownify`.  Whoops.