### PR TITLE
Include substitution of year in user-defined copyright strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,9 +87,9 @@ Blogging from Texas
 Add your own favicon in `static/favicons/favicon.ico`.
 
 ### Copyright
-By default, the copyright will show the authors name followed by the current year, but you can change this by configuring the `copyright` parameter.
+By default, the copyright will show the authors name followed by the current year, but you can change this by configuring the `copyright` parameter.  If this method is used, the string `{{ YEAR }}` will be replaced with the current year during site generation.
 ```toml
-copyright = "2020-2021"
+copyright = "2020-{{ YEAR }}"
 ```
 
 ### Navigation items

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -18,6 +18,6 @@
         {{ end }}
     </ul>
     <div class="footer">
-        <div class="by_farbox">&copy; {{ if isset .Site.Params "copyright" }} {{ .Site.Params.copyright | markdownify }} {{ else }} {{ .Site.Params.author }} {{ now.Format "2006"}} {{end}}</div>
+        <div class="by_farbox">&copy; {{ if isset .Site.Params "copyright" }} {{ replace .Site.Params.copyright "{{ YEAR }}" (now.Format "2006") | markdownify }} {{ else }} {{ .Site.Params.author }} {{ now.Format "2006"}} {{end}}</div>
     </div>
 </div>


### PR DESCRIPTION
Document as well

See #206 and #208.  Sorry for the noise.