### PR TITLE
add favicon files info to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Anatole is a beautiful minimalist two-column [hugo](https://gohugo.io/) theme ba
 
 ## Features
 
-Anatole's aims to be minimalistic and sleek, but still brings some great functionality.
+Anatole's aims to be minimalistic and sleek but still brings some great functionality.
 
 ### Features include
 
@@ -217,7 +217,7 @@ fullPostContent = true
 
 ### Multilingual support
 
-Anatole supports multilingual page setups. All you need to do is to add the languages to your 'config.toml'. For each language you can set the custom options like title or description. It's important to include a `LanguageName`, as it will be displayed in the main menu.
+Anatole supports multilingual page setups. All you need to do is to add the languages to your 'config.toml'. For each language, you can set the custom options like title or description. It's important to include a `LanguageName`, as it will be displayed in the main menu.
 
 ```toml
 [Languages]
@@ -233,7 +233,7 @@ Anatole supports multilingual page setups. All you need to do is to add the lang
   LanguageName = "DE"
 ```
 
-There are two ways of translating your content either by adding a suffix in the filename eg. `mypost.de.md` or by setting a contentDir (a certain directory) for each language. [Link to the Hugo documentation](https://gohugo.io/content-management/multilingual/). If you want to use the option with the `contentDir`, you will have to add the `contentDir` parameter for each language:
+There are two ways of translating your content, either by adding a suffix in the filename, eg. `mypost.de.md`, or by setting a contentDir (a certain directory) for each language. [Link to the Hugo documentation](https://gohugo.io/content-management/multilingual/). If you want to use the option with the `contentDir`, you will have to add the `contentDir` parameter for each language:
 
 ```toml
 [languages]
@@ -269,7 +269,7 @@ Anatole currently ships with support for some basic languages. Contributions for
 
 ### RTL support
 
-Anatole support RTL langauges and flip the whole theme for that. To enable the RTL mode for specific langauge it's enough to write the following code in the language params.
+Anatole supports RTL languages and flip the whole theme for that. To enable the RTL-mode for a specific language, it's enough to write the following code in the language params.
 
 ```toml
 LanguageDirection = "rtl"
@@ -303,7 +303,7 @@ theme= "preferred-color-scheme"
 Two notes on the security of Utteranc.es
 
 - If you are using a strict CSP, you'll have to add the domain to it.
-- The script currently has no built-in integrity check, due to limitations of [Utterances](https://github.com/utterance/utterances/issues/40).
+- The script currently has no built-in integrity check due to limitations of [Utterances](https://github.com/utterance/utterances/issues/40).
 
 ### Comments powered by Commento
 
@@ -326,7 +326,7 @@ To use Google Analytics, a valid tracking code has to be added. If you don't wan
 googleAnalytics = "UA-123-45"
 ```
 
-To use the modern Google Analytics 4, include the following under `[params]` replacing the id with your own.
+To use the modern Google Analytics 4, include the following under `[params]`, replacing the id with your own.
 
 ```toml
 [params]
@@ -438,7 +438,7 @@ You can add your custom JS files with the `customJs` parameter of the configurat
 customJs = ["js/hello.js", "js/world.js"]
 ```
 
-On the user-side it will look like this:
+On the user-side, it will look like this:
 
 ```text
 .
@@ -450,7 +450,7 @@ On the user-side it will look like this:
 
 `hello.js` and `world.js` will be bundled into a `custom.min.js`.
 
-You can also include links to remote javascript files (hosted on CDNs for example). But be aware, that integrity settings and minification won't be applied. Further make sure to adjust your CSP. You can load a remote script like this:
+You can also include links to remote javascript files (hosted on CDNs for example). But be aware that integrity settings and minification won't be applied. Further, make sure to adjust your CSP. You can load a remote script like this:
 
 ```toml
 [params]
@@ -475,7 +475,7 @@ enableMediumZoom = false
 
 ### Content Security Policy
 
-The theme is compliant with most strict CSP policies out of the box. A sample CSP for an Anatole-based site would look something like this:
+The theme is compliant with the most strict CSP policies out of the box. A sample CSP for an Anatole-based site would look something like this:
 
 ```text
 Content-Security-Policy "
@@ -515,7 +515,7 @@ You can configure the pages shown on the front page by altering the `mainSection
 
 ### Robots.txt
 
-If you want Hugo to generate a robots.txt, you will have to set the `enableRobotsTXT` in the `config.toml` to `true`. By default a robots.txt, which allows search engine crawlers to access to any page, will be generated. It will look like this:
+If you want Hugo to generate a robots.txt, you will have to set the `enableRobotsTXT` in the `config.toml` to `true`. By default, a robots.txt, which allows search engine crawlers to access to any page, will be generated. It will look like this:
 
 ```text
 User-agent: *
@@ -525,7 +525,7 @@ If certain sites should be excluded from being accessed, you might want to setup
 
 ### Syntax highlighting
 
-This theme has support for either Hugo's lightning-fast Chroma code highlighting. See the [Hugo docs](https://gohugo.io/content-management/syntax-highlighting/) for more information.
+This theme has support for Hugo's lightning-fast Chroma code highlighting. See the [Hugo docs](https://gohugo.io/content-management/syntax-highlighting/) for more information.
 
 To enable Chroma, add the following to your site parameters:
 
@@ -558,7 +558,7 @@ If you are using brand icons, prefix the icon value with `fab` if you are using 
 
 Ordering in the `config.toml` will determine the display order on the webpage.
 
-#### Example branded social entry
+#### Sample branded social entry
 
 ```toml
 [[params.socialIcons]]
@@ -567,7 +567,7 @@ title = "Linkedin"
 url = "https://de.linkedin.com/"
 ```
 
-#### Example standard social entry
+#### Sample standard social entry
 
 ```toml
 [[params.socialIcons]]
@@ -605,7 +605,7 @@ Anatole is licensed under the [MIT license](https://github.com/lxndrblz/anatole/
 
 ## Maintenance
 
-This theme is maintained by its author [Alexander Bilz](https://github.com/lxndrblz) and with the help from these awesome [contributors](https://github.com/lxndrblz/anatole/graphs/contributors). Please open an issue/pull request if you want to contribute to making this theme better and more feature-complete. For PRs please make sure that they align with theme's goals: minimalism, speed and elegance.
+This theme is maintained by its author [Alexander Bilz](https://github.com/lxndrblz) and with the help from these awesome [contributors](https://github.com/lxndrblz/anatole/graphs/contributors). Please open an issue/pull request if you want to contribute to making this theme better and more feature-complete. For PRs, please make sure that they align with the theme's goals: minimalism, speed and elegance.
 
 ## Sponsoring
 

--- a/README.md
+++ b/README.md
@@ -70,9 +70,11 @@ author = "Jane Doe"
 description = "Call me Jane"
 profilePicture = "images/profile.jpg"
 ```
+
 Please note that the title under the `[params]` only adjusts the page title in the sidebar. If you wish to adjust the HTML title (i.e. name of the tab), you will have to adjust the Hugo's title variable, as shown in the `config.toml`.
 
 Please note that the slogan can be multi-lined (note the three quotes at the beginning and end):
+
 ```toml
 [params]
 description = """
@@ -81,13 +83,19 @@ Blogging from Texas
 """
 ```
 
-
 ### Favicon
 
-Add your own favicon in `static/favicons/favicon.ico`.
+Add your favicons to `static/favicons`. Anatole currently employs following favicon files:
+
+- `favicon.ico`
+- `favicon-16x16.png`
+- `favicon-32x32.png`
+- `apple-touch-icon.png` (resolution should be 180x180)
 
 ### Copyright
+
 By default, the copyright will show the current year, but you can change this by configuring the `copyright` parameter.
+
 ```toml
 copyright = "2020-2021"
 ```
@@ -130,21 +138,27 @@ displayMode = "dark"
 ```
 
 ### Disable Theme Switcher
+
 You can easily disable the theme switcher from the `config.toml`. All you have to do is to set the parameter `disableThemeSwitcher` to `true`.
+
 ```toml
 [params]
 disableThemeSwitcher = true # Theme switcher is enabled by default
 ```
 
 ### Disable Animations
+
 You can easily disable the animations from the `config.toml`. All you have to do is to set the parameter `doNotLoadAnimations` to `true`.
+
 ```toml
 [params]
 doNotLoadAnimations = true # Animations are loaded by default
 ```
 
 ### Control the date Format
+
 You can change the default date formating for the `list.html`, the `single.html` and the `index.html`. Simply configure the matching parameters.
+
 ```toml
 [params]
 singleDateFormat = "Mon, Jan 2, 2006"
@@ -153,28 +167,36 @@ listDateFormat = "Jan 2"
 ```
 
 ### Changing the sidebar/content ratio
+
 By default, the content fills up 60% of the screen width on devices with a full HD resolution. If you want to change the ratio, adjust the `contentratio` variable. Let's, for example, set the content ratio to 70%:
+
 ```toml
 [params]
 contentratio = 0.7
 ```
 
 ### Read-more Links
+
 You can enable read-more links for truncated posts by setting the `readMore = true`. The length of the preview is controlled by Hugo's `summarylength`. Read-more links are disabled by default.
+
 ```toml
 [params]
   readMore = true
 ```
 
 ### Have a static page as a home page
+
 If you prefer having a static page as your home page rather than a listing of the latest posts, then make sure you leave the `mainSections` parameter blank:
+
 ```toml
 [params]
   mainSections = []
 ```
+
 Put any content into the `_index.md` file located in the content directory. If you want, you can also have some static text and the posts below. In such case, simply keep the `mainSections = ["post"]` and put any static content in the `_index.md`.
 
 ### Rename post section
+
 If you want to have a different post section identifier, such as `/blog`, you can specify the section name using `postSectionName`:
 
 ```toml
@@ -185,7 +207,9 @@ If you want to have a different post section identifier, such as `/blog`, you ca
 If the parameter is not set, it will default to `post`. Be sure to check the name of the folder containing your post files and change it accordingly in order for links to reflect the new post section name.
 
 ### Show full post content on the home page
+
 If you prefer the full content of your posts to appear on the home page rather than a summary of each post, then set the parameter `fullPostContent` to `true`.
+
 ```toml
 [params]
 fullPostContent = true
@@ -243,14 +267,13 @@ url = "/de/about/"
 
 Anatole currently ships with support for some basic languages. Contributions for other language translations are welcome.
 
-### RTL suppourt 
+### RTL suppourt
 
 Anatole support RTL langauges and flip the whole theme for that. To enable the RTL mode for specific langauge it's enough to write the following code in the language params.
 
 ```toml
-LanguageDirection = "rtl" 
+LanguageDirection = "rtl"
 ```
-
 
 ### :100: Google Lighthouse score
 
@@ -274,14 +297,16 @@ No comment section is shown on the `single.html` unless a `repo` is specified in
 repo = "githubuser/reponame"
 issueTerm = "pathname"
 theme= "preferred-color-scheme"
-# label = 
+# label =
 ```
 
 Two notes on the security of Utteranc.es
-- If you are using a strict CSP, you'll have to add the domain to it. 
+
+- If you are using a strict CSP, you'll have to add the domain to it.
 - The script currently has no built-in integrity check, due to limitations of [Utterances](https://github.com/utterance/utterances/issues/40).
 
 ### Comments powered by Commento
+
 You can use [Commento](https://commento.io/) as an alternative to Disqus. All you need to do is to configure a `CommentoURL`:
 
 ```toml
@@ -292,7 +317,6 @@ CommentoURL = "https://commento.example.com/js/commento.js"
 ### Disabling Comments Per Page
 
 Comments can be disabled per page by setting `disableComments: true` on the pages [Front Matter](https://gohugo.io/content-management/front-matter/)
-
 
 ### Google Analytics
 
@@ -338,13 +362,18 @@ Replace the hash with the one Google provided you.
 enable = false  # options: true, false. Enable math support globally, default: false. You can always enable math on per page.
 use = "katex"  # options: "katex", "mathjax". default is "katex".
 ```
+
 ### Formspree Contact Form on the Contact page
+
 Step 1: Configure the `contactFormAction` in the `config.toml`
+
 ```toml
 [params]
 #contactFormAction = "https://formspree.io/f/your-form-hash-here"
 ```
-Step 2: Activate the `contact: true` or  `contact=true` in the frontmatter of a page. See `exampleSite/content/contact.html` as an example.
+
+Step 2: Activate the `contact: true` or `contact=true` in the frontmatter of a page. See `exampleSite/content/contact.html` as an example.
+
 ### Twitter Cards support
 
 In order to use the full functionality of Twitter cards, you will have to define a couple of settings in the `config.toml` and the frontmatter of a page.
@@ -361,21 +390,25 @@ To define a custom image of a page, you might want to add the following to the f
 ```toml
 images = ["post-cover.png"]
 ```
+
 ### Open Graph Support
 
 The [internal template for Open Graph protocol](https://gohugo.io/templates/internal/#open-graph) uses a mix of configuration variables; settings in `config.toml` and frontmatter of the page. In a nutshell, you will have to configure a taxonomies series.
 
 ### Post Thumbnails
+
 Thumbnails can be enabled easily by setting the `thumbnail` parameter in the frontmatter of a post to an image such as `"images/landscape.jpg"`.
+
 ```md
 +++
 ...
 tags = [
-    "thumbnail",
+"thumbnail",
 ]
 thumbnail= "images/landscape.jpg"
 +++
 ```
+
 Make sure to put the image in the `static/images/` directory.
 
 ### Custom CSS
@@ -549,14 +582,13 @@ Anatole is licensed under the [MIT license](https://github.com/lxndrblz/anatole/
 
 ## Maintenance
 
-This theme is maintained by its author [Alexander Bilz](https://github.com/lxndrblz) and with the help from these awesome [contributors](https://github.com/lxndrblz/anatole/graphs/contributors). Please open an issue/pull request if you want to contribute to making this theme better and more feature-complete. For PRs please make sure that they align with theme's goals: minimalism, speed and elegance.  
+This theme is maintained by its author [Alexander Bilz](https://github.com/lxndrblz) and with the help from these awesome [contributors](https://github.com/lxndrblz/anatole/graphs/contributors). Please open an issue/pull request if you want to contribute to making this theme better and more feature-complete. For PRs please make sure that they align with theme's goals: minimalism, speed and elegance.
 
 ## Sponsoring
 
 If you like this theme, give it a star on GitHub, and consider supporting its development:
 
 [![ko-fi](https://www.ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/lxndrblz/)
-
 
 ## Special Thanks 🎁
 

--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ url = "/de/about/"
 
 Anatole currently ships with support for some basic languages. Contributions for other language translations are welcome.
 
-### RTL suppourt
+### RTL support
 
 Anatole support RTL langauges and flip the whole theme for that. To enable the RTL mode for specific langauge it's enough to write the following code in the language params.
 


### PR DESCRIPTION
This adds missing favicon files info to the docs for users to know which files to provide.