### PR TITLE
Add Option for Main Sections Heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -513,6 +513,9 @@ You can configure the pages shown on the front page by altering the `mainSection
   mainSections = ["post", "docs"]
 ```
 
+### _index.md and post section header
+You can place custom content, by creating `_index.md` markdown file within the content directory. An example can be found [here](https://github.com/lxndrblz/anatole/blob/exampleSite/content/english/_index.md). Uncomment the section as needed. This file `_index.md` also has a parameter called `mainSectionsTitle`, which lets you specify a header for the posts on the main page. This header will be styled and placed always after the content of the `_index.md` it self.  
+
 ### Robots.txt
 
 If you want Hugo to generate a robots.txt, you will have to set the `enableRobotsTXT` in the `config.toml` to `true`. By default, a robots.txt, which allows search engine crawlers to access to any page, will be generated. It will look like this:

--- a/exampleSite/content/arabic/_index.md
+++ b/exampleSite/content/arabic/_index.md
@@ -3,7 +3,7 @@ author = "Hugo Authors"
 +++
 
 <!--
-This file is left intentionally empty by default to be backward compatible with initial theme setup.
+This file is left intentionally empty by default to be backwards compatible with the initial theme setup.
 
 Although the theme has advanced a little bit and it now allows to specify the content on the main page (even if the list of posts/articles is not intended).
 This can be:
@@ -21,4 +21,5 @@ Markdown supported, ie:
 Don't forget to check the README.md file!
 ```
 
+Remember that you can also specify a section header for the posts below by configuring the `mainSectionsTitle` parameter in the front matter of this file.
 -->

--- a/exampleSite/content/english/_index.md
+++ b/exampleSite/content/english/_index.md
@@ -3,7 +3,7 @@ author = "Hugo Authors"
 +++
 
 <!--
-This file is left intentionally empty by default to be backward compatible with initial theme setup.
+This file is left intentionally empty by default to be backwards compatible with the initial theme setup.
 
 Although the theme has advanced a little bit and it now allows to specify the content on the main page (even if the list of posts/articles is not intended).
 This can be:
@@ -21,4 +21,5 @@ Markdown supported, ie:
 Don't forget to check the README.md file!
 ```
 
+Remember that you can also specify a section header for the posts below by configuring the `mainSectionsTitle` parameter in the front matter of this file.
 -->

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -13,6 +13,14 @@
         -->
     </div>
 
+    {{ if .Params.mainSectionsTitle }}
+    <div class="post {{ with .Site.Params.doNotLoadAnimations }} . {{ else }} animated fadeInDown {{ end }}">
+        <div class="post-title post-content">
+            <h2>{{ .Params.mainSectionsTitle }}</h2>
+        </div>
+    </div>
+    {{ end }}
+
     {{ $paginator := .Paginate (where .Site.RegularPages "Type" "in" .Site.Params.mainSections) }}
     {{ range $paginator.Pages }}
 


### PR DESCRIPTION
On my personal website I have static content in `_index.md` which I use to introduce myself. Beneath I render the posts using `mainSections`. The problem with this approach and the current theme layout is that the posts appear without context beneath the content of `_index.md`.

You might think that you could add a heading in `_index.md` as the very last content. However, using markdown the appearance just isn't right. You'd need HTML and CSS to make it look pleasing. I think this is a more common issue so that it makes sense to offer a 'native' way offered by the theme; hence I propose this PR.