### PR TITLE
Fix Navigation Item Centering

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -217,10 +217,6 @@ header .nav__list li {
     display: initial;
 }
 
-header .nav__list li:not(:last-of-type) {
-    padding-right: 20px;
-}
-
 header .nav__list a {
     color: var(--nav-text-color);
 }
@@ -919,6 +915,10 @@ a.btn {
 @media screen and (min-width: 960px), print {
     header {
         border-bottom: 1px solid var(--border-color);
+    }
+    
+    header .nav__list li:not(:last-of-type) {
+        padding-right: 20px;
     }
 
     .sidebar {

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -917,7 +917,7 @@ a.btn {
         border-bottom: 1px solid var(--border-color);
     }
     
-    header .nav__list li:not(:last-of-type) {
+    .nav__links li:not(:last-of-type) {
         padding-right: 20px;
     }
 


### PR DESCRIPTION
Due to the latest changes, the last navigation item of `nav__list` is not centered. This results from the padding used for the top navbar view breaking through which in turn is not applied on the last element. This PR fixes this issue by only adding paddings for the top navbar view. Futhermore, I only applied the styles to `nav__links` to be more specific.

See the item 'EN' being mispaced:
![image](https://user-images.githubusercontent.com/35292572/123143514-f8212900-d45a-11eb-8166-fd5e698a69a5.png)
