### PR TITLE
Add Code Formatting with Prettier

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -45,23 +45,24 @@ html[data-theme='dark'] {
 }
 
 html {
-  background-color: var(--bg-color);
-  -webkit-font-smoothing: antialiased;
+    background-color: var(--bg-color);
+    -webkit-font-smoothing: antialiased;
+    font-size: 62.5%;
 }
 
 body {
-  color: var(--body-color);
-  font-family: 'PingHei', 'PingFang SC', 'Helvetica Neue', 'Work Sans', 'Hiragino Sans GB', sans-serif;
-  font-size: 15px;
-  width: 100%;
-  margin: 0 auto;
-  background-color: var(--bg-color);
+    color: var(--body-color);
+    font-family: 'PingHei', 'PingFang SC', 'Helvetica Neue', 'Work Sans', 'Hiragino Sans GB', sans-serif;
+    font-size: 1.5rem;
+    width: 100%;
+    margin: 0 auto;
+    background-color: var(--bg-color);
 }
 
 p {
-  line-height: 1.9em;
-  font-weight: 400;
-  font-size: 14px;
+    line-height: 1.9em;
+    font-weight: 400;
+    font-size: 1.4rem;
 }
 
 a {
@@ -90,10 +91,10 @@ blockquote {
 
 .tag,
 .category {
-  display: inline-block;
-  font-size: 15px;
-  line-height: 1;
-  margin: 5px 8px 5px 0;
+    display: inline-block;
+    font-size: 1.5rem;
+    line-height: 1;
+    margin: 5px 8px 5px 0;
 }
 
 pre {
@@ -208,9 +209,9 @@ header {
 }
 
 header .nav__list {
-  list-style: none;
-  padding: 20px 30px;
-  font-size: 12px;
+    list-style: none;
+    padding: 20px 30px;
+    font-size: 1.2rem;
 }
 
 header .nav__list li {
@@ -233,9 +234,9 @@ header .nav__list a.current {
 }
 
 .theme-switch {
-  margin-top: -5px;
-  color: var(--nav-text-color);
-  font-size: 1rem;
+    margin-top: -5px;
+    color: var(--nav-text-color);
+    font-size: 1.75rem;
 }
 
 header .information {
@@ -285,8 +286,8 @@ aside {
 }
 
 .sidebar .logo-title .description {
-  font-size: 14px;
-  margin: 0 1em;
+    font-size: 1.4rem;
+    margin: 0 1em;
 }
 
 .sidebar .logo-title .logo {
@@ -300,26 +301,26 @@ aside {
 }
 
 .sidebar .logo-title .title h3 {
-  text-transform: uppercase;
-  font-size: 2rem;
-  font-weight: bold;
-  letter-spacing: 2px;
-  line-height: 1;
-  margin: 1em;
+    text-transform: uppercase;
+    font-size: 2.2rem;
+    font-weight: bold;
+    letter-spacing: 2px;
+    line-height: 1;
+    margin: 1em;
 }
 
 .sidebar .logo-title .title a {
-  text-decoration: none;
-  color: var(--heading-color);
-  font-size: 2rem;
-  font-weight: bold;
+    text-decoration: none;
+    color: var(--heading-color);
+    font-size: 3rem;
+    font-weight: bold;
 }
 
 .sidebar .social-links {
-  list-style: none;
-  padding: 0;
-  font-size: 14px;
-  text-align: center;
+    list-style: none;
+    padding: 0;
+    font-size: 1.4rem;
+    text-align: center;
 }
 
 .sidebar .social-links i {
@@ -346,30 +347,30 @@ aside {
 }
 
 .post .post-title h1 {
-  text-transform: uppercase;
-  font-size: 30px;
-  letter-spacing: 1px;
-  line-height: 1;
+    text-transform: uppercase;
+    font-size: 3.0rem;
+    letter-spacing: 1px;
+    line-height: 1;
 }
 
 .post .post-title h2 {
-  text-transform: uppercase;
-  letter-spacing: 1px;
-  font-size: 28px;
-  line-height: 1;
-  font-weight: 600;
-  color: var(--heading-color);
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    font-size: 2.6rem;
+    line-height: 1;
+    font-weight: 600;
+    color: var(--heading-color);
 }
 
 .post .post-title h3 {
-  text-transform: uppercase;
-  letter-spacing: 1px;
-  line-height: 1;
-  font-weight: 600;
-  /* color: #464646; */
-  color: var(--heading-color);
-  font-size: 22px;
-  margin: 0;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    line-height: 1;
+    font-weight: 600;
+    /* color: #464646; */
+    color: var(--heading-color);
+    font-size: 2.2rem;
+    margin: 0;
 }
 
 .post .post-title a {
@@ -394,14 +395,23 @@ aside {
   color: #2f69b3;
 }
 
+.post .post-content h1 {
+    font-size: 3.0rem;
+}
+
+.post .post-content h2 {
+    font-size: 2.6rem;
+    font-weight: 600;
+}
+
 .post .post-content h3 {
-  font-size: 22px;
-  font-weight: 600;
+    font-weight: 600;
+    font-size: 2.2rem;
 }
 
 .post .post-content h4 {
-  /* color: var(--heading-color); */
-  font-size: 16px;
+    /* color: var(--heading-color); */
+    font-size:  1.6rem;
 }
 
 .post .post-content img {
@@ -409,15 +419,15 @@ aside {
 }
 
 .post .post-content ul {
-  line-height: 1.9em;
-  font-weight: 400;
-  font-size: 14px;
+    line-height: 1.9em;
+    font-weight: 400;
+    font-size: 1.4rem;
 }
 
 .post .post-content ol {
-  line-height: 1.9em;
-  font-weight: 400;
-  font-size: 14px;
+    line-height: 1.9em;
+    font-weight: 400;
+    font-size: 1.4rem;
 }
 
 .post .post-footer {
@@ -432,10 +442,10 @@ aside {
 }
 
 .post .post-footer .meta .info {
-  float: left;
-  font-size: 12px;
-  margin-bottom: 1em;
-  color: var(--body-color);
+    float: left;
+    font-size: 1.2rem;
+    margin-bottom: 1em;
+    color: var(--body-color);
 }
 
 .post .post-footer .info .separator a {
@@ -492,8 +502,8 @@ aside {
 }
 
 .post .post-footer .tags {
-  padding-bottom: 15px;
-  font-size: 13px;
+    padding-bottom: 15px;
+    font-size: 1.3rem;
 }
 
 .post .post-footer .tags ul {
@@ -595,15 +605,15 @@ aside {
 }
 
 .footer {
-  clear: both;
-  text-align: center;
-  font-size: 10px;
-  margin: 0 auto;
-  bottom: 0;
-  width: 100%;
-  padding-bottom: 20px;
-  flex: 0;
-  position: relative;
+    clear: both;
+    text-align: center;
+    font-size: 1rem;
+    margin: 0 auto;
+    bottom: 0;
+    width: 100%;
+    padding-bottom: 20px;
+    flex: 0;
+    position: relative;
 }
 
 .footer a {
@@ -632,9 +642,9 @@ aside {
 }
 
 .list-with-title {
-  font-size: 14px;
-  margin: 30px;
-  padding: 0;
+    font-size: 1.4rem;
+    margin: 30px;
+    padding: 0;
 }
 
 .list-with-title li {
@@ -643,10 +653,10 @@ aside {
 }
 
 .list-with-title .listing-title {
-  font-size: 24px;
-  color: #666666;
-  font-weight: 600;
-  line-height: 2.2em;
+    font-size: 2.4rem;
+    color: #666666;
+    font-weight: 600;
+    line-height: 2.2em;
 }
 
 .list-with-title .listing {
@@ -690,9 +700,9 @@ aside {
 }
 
 .evernote a {
-  color: #fff;
-  padding: 11px;
-  font-size: 12px;
+    color: #fff;
+    padding: 11px;
+    font-size: 1.2rem;
 }
 
 .evernote a:hover {
@@ -740,7 +750,7 @@ aside {
 }
 
 .about h3 {
-  font-size: 22px;
+    font-size: 2.2rem;
 }
 
 /* links*/
@@ -749,7 +759,7 @@ aside {
 }
 
 .links h3 {
-  font-size: 22px;
+    font-size: 2.2rem;
 }
 
 .links a {
@@ -766,7 +776,7 @@ aside {
 }
 
 .read_more {
-  font-size: 14px;
+    font-size: 1.4rem;
 }
 
 .back-button {
@@ -792,37 +802,37 @@ a.btn {
 }
 
 .btn {
-  display: inline-block;
-  position: relative;
-  outline: 0;
-  color: var(--post-color);
-  background: transparent;
-  font-size: 14px;
-  text-align: center;
-  text-decoration: none;
-  cursor: pointer;
-  border: 1px solid var(--border-color);
-  white-space: nowrap;
-  font-weight: 400;
-  font-style: normal;
-  border-radius: 999em;
+    display: inline-block;
+    position: relative;
+    outline: 0;
+    color: var(--post-color);
+    background: transparent;
+    font-size: 1.4rem;
+    text-align: center;
+    text-decoration: none;
+    cursor: pointer;
+    border: 1px solid var(--border-color);
+    white-space: nowrap;
+    font-weight: 400;
+    font-style: normal;
+    border-radius: 999em;
 }
 
 .btn:hover {
-  display: inline-block;
-  position: relative;
-  outline: 0px;
-  color: #464545;
-  background: transparent;
-  font-size: 14px;
-  text-align: center;
-  text-decoration: none;
-  cursor: pointer;
-  border: 1px solid #464545;
-  white-space: nowrap;
-  font-weight: 400;
-  font-style: normal;
-  border-radius: 999em;
+    display: inline-block;
+    position: relative;
+    outline: 0px;
+    color: #464545;
+    background: transparent;
+    font-size: 1.4rem;
+    text-align: center;
+    text-decoration: none;
+    cursor: pointer;
+    border: 1px solid #464545;
+    white-space: nowrap;
+    font-weight: 400;
+    font-style: normal;
+    border-radius: 999em;
 }
 
 [role='back'] {
@@ -860,40 +870,40 @@ a.btn {
 }
 
 .menu .btn-down li a {
-  display: inline-block;
-  position: relative;
-  padding: 0.5em 1.25em;
-  outline: 0;
-  color: var(--post-color);
-  background: transparent;
-  font-size: 14px;
-  text-align: center;
-  text-decoration: none;
-  cursor: pointer;
-  border: 1px solid var(--border-color);
-  white-space: nowrap;
-  font-weight: 400;
-  font-style: normal;
-  border-radius: 999em;
-  margin-top: 5px;
+    display: inline-block;
+    position: relative;
+    padding: 0.5em 1.25em;
+    outline: 0;
+    color: var(--post-color);
+    background: transparent;
+    font-size: 1.4rem;
+    text-align: center;
+    text-decoration: none;
+    cursor: pointer;
+    border: 1px solid var(--border-color);
+    white-space: nowrap;
+    font-weight: 400;
+    font-style: normal;
+    border-radius: 999em;
+    margin-top: 5px;
 }
 
 .menu .btn-down li a:hover {
-  position: relative;
-  padding: 0.5em 1.25em;
-  outline: 0;
-  color: #fff;
-  background: #3cbd10;
-  font-size: 14px;
-  text-align: center;
-  text-decoration: none;
-  cursor: pointer;
-  border: 1px solid rgba(0, 0, 0, 0.15);
-  white-space: nowrap;
-  font-weight: 400;
-  font-style: normal;
-  border-radius: 999em;
-  margin-top: 5px;
+    position: relative;
+    padding: 0.5em 1.25em;
+    outline: 0;
+    color: #fff;
+    background: #3CBD10;
+    font-size: 1.4rem;
+    text-align: center;
+    text-decoration: none;
+    cursor: pointer;
+    border: 1px solid rgba(0, 0, 0, 0.15);
+    white-space: nowrap;
+    font-weight: 400;
+    font-style: normal;
+    border-radius: 999em;
+    margin-top: 5px;
 }
 
 .menu .btn-down div {
@@ -921,20 +931,18 @@ a.btn {
     padding-right: 20px;
   }
 
-  .sidebar {
-    height: 100vh;
-    display: flex;
-    flex-direction: column;
-    position: fixed;
-    width: var(--sidebar-width);
-  }
-
-  .sidebar__content {
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    flex-grow: 1;
-  }
+    .sidebar__content {
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        flex-grow: 1;
+    }
+    
+    .navbar {
+        display: flex;
+        flex-direction: column;
+        justify-content: space-between;
+    }
 
   .navbar {
     display: flex;
@@ -981,9 +989,9 @@ a.btn {
     height: 100px;
   }
 
-  .sidebar .logo-title .title h3 {
-    font-size: 20px;
-  }
+    .sidebar .logo-title .title h1 {
+        font-size: 2.2rem;
+    }
 
   header {
     width: 100%;
@@ -1179,15 +1187,15 @@ a.btn {
   min-height: 35px;
 }
 .form-style ul li .field-style {
-  box-sizing: border-box;
-  -webkit-box-sizing: border-box;
-  -moz-box-sizing: border-box;
-  font-size: 14px;
-  padding: 8px;
-  outline: none;
-  background-color: var(--bg-color);
-  border: 1px solid var(--form-border-color);
-  color: var(--body-color);
+    box-sizing: border-box; 
+    -webkit-box-sizing: border-box;
+    -moz-box-sizing: border-box; 
+    font-size: 1.4rem;
+    padding: 8px;
+    outline: none;
+    background-color: var(--bg-color);
+    border: 1px solid var(--form-border-color);
+    color: var(--body-color);
 }
 .form-style ul li .field-style:focus {
   box-shadow: 0 0 5px;

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -45,24 +45,24 @@ html[data-theme='dark'] {
 }
 
 html {
-    background-color: var(--bg-color);
-    -webkit-font-smoothing: antialiased;
-    font-size: 62.5%;
+  background-color: var(--bg-color);
+  -webkit-font-smoothing: antialiased;
+  font-size: 62.5%;
 }
 
 body {
-    color: var(--body-color);
-    font-family: 'PingHei', 'PingFang SC', 'Helvetica Neue', 'Work Sans', 'Hiragino Sans GB', sans-serif;
-    font-size: 1.5rem;
-    width: 100%;
-    margin: 0 auto;
-    background-color: var(--bg-color);
+  color: var(--body-color);
+  font-family: 'PingHei', 'PingFang SC', 'Helvetica Neue', 'Work Sans', 'Hiragino Sans GB', sans-serif;
+  font-size: 1.5rem;
+  width: 100%;
+  margin: 0 auto;
+  background-color: var(--bg-color);
 }
 
 p {
-    line-height: 1.9em;
-    font-weight: 400;
-    font-size: 1.4rem;
+  line-height: 1.9em;
+  font-weight: 400;
+  font-size: 1.4rem;
 }
 
 a {
@@ -91,10 +91,10 @@ blockquote {
 
 .tag,
 .category {
-    display: inline-block;
-    font-size: 1.5rem;
-    line-height: 1;
-    margin: 5px 8px 5px 0;
+  display: inline-block;
+  font-size: 1.5rem;
+  line-height: 1;
+  margin: 5px 8px 5px 0;
 }
 
 pre {
@@ -209,9 +209,9 @@ header {
 }
 
 header .nav__list {
-    list-style: none;
-    padding: 20px 30px;
-    font-size: 1.2rem;
+  list-style: none;
+  padding: 20px 30px;
+  font-size: 1.2rem;
 }
 
 header .nav__list li {
@@ -234,9 +234,9 @@ header .nav__list a.current {
 }
 
 .theme-switch {
-    margin-top: -5px;
-    color: var(--nav-text-color);
-    font-size: 1.75rem;
+  margin-top: -5px;
+  color: var(--nav-text-color);
+  font-size: 1.75rem;
 }
 
 header .information {
@@ -286,8 +286,8 @@ aside {
 }
 
 .sidebar .logo-title .description {
-    font-size: 1.4rem;
-    margin: 0 1em;
+  font-size: 1.4rem;
+  margin: 0 1em;
 }
 
 .sidebar .logo-title .logo {
@@ -301,26 +301,26 @@ aside {
 }
 
 .sidebar .logo-title .title h3 {
-    text-transform: uppercase;
-    font-size: 2.2rem;
-    font-weight: bold;
-    letter-spacing: 2px;
-    line-height: 1;
-    margin: 1em;
+  text-transform: uppercase;
+  font-size: 2.2rem;
+  font-weight: bold;
+  letter-spacing: 2px;
+  line-height: 1;
+  margin: 1em;
 }
 
 .sidebar .logo-title .title a {
-    text-decoration: none;
-    color: var(--heading-color);
-    font-size: 3rem;
-    font-weight: bold;
+  text-decoration: none;
+  color: var(--heading-color);
+  font-size: 3rem;
+  font-weight: bold;
 }
 
 .sidebar .social-links {
-    list-style: none;
-    padding: 0;
-    font-size: 1.4rem;
-    text-align: center;
+  list-style: none;
+  padding: 0;
+  font-size: 1.4rem;
+  text-align: center;
 }
 
 .sidebar .social-links i {
@@ -347,30 +347,30 @@ aside {
 }
 
 .post .post-title h1 {
-    text-transform: uppercase;
-    font-size: 3.0rem;
-    letter-spacing: 1px;
-    line-height: 1;
+  text-transform: uppercase;
+  font-size: 3rem;
+  letter-spacing: 1px;
+  line-height: 1;
 }
 
 .post .post-title h2 {
-    text-transform: uppercase;
-    letter-spacing: 1px;
-    font-size: 2.6rem;
-    line-height: 1;
-    font-weight: 600;
-    color: var(--heading-color);
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  font-size: 2.6rem;
+  line-height: 1;
+  font-weight: 600;
+  color: var(--heading-color);
 }
 
 .post .post-title h3 {
-    text-transform: uppercase;
-    letter-spacing: 1px;
-    line-height: 1;
-    font-weight: 600;
-    /* color: #464646; */
-    color: var(--heading-color);
-    font-size: 2.2rem;
-    margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  line-height: 1;
+  font-weight: 600;
+  /* color: #464646; */
+  color: var(--heading-color);
+  font-size: 2.2rem;
+  margin: 0;
 }
 
 .post .post-title a {
@@ -396,22 +396,22 @@ aside {
 }
 
 .post .post-content h1 {
-    font-size: 3.0rem;
+  font-size: 3rem;
 }
 
 .post .post-content h2 {
-    font-size: 2.6rem;
-    font-weight: 600;
+  font-size: 2.6rem;
+  font-weight: 600;
 }
 
 .post .post-content h3 {
-    font-weight: 600;
-    font-size: 2.2rem;
+  font-weight: 600;
+  font-size: 2.2rem;
 }
 
 .post .post-content h4 {
-    /* color: var(--heading-color); */
-    font-size:  1.6rem;
+  /* color: var(--heading-color); */
+  font-size: 1.6rem;
 }
 
 .post .post-content img {
@@ -419,15 +419,15 @@ aside {
 }
 
 .post .post-content ul {
-    line-height: 1.9em;
-    font-weight: 400;
-    font-size: 1.4rem;
+  line-height: 1.9em;
+  font-weight: 400;
+  font-size: 1.4rem;
 }
 
 .post .post-content ol {
-    line-height: 1.9em;
-    font-weight: 400;
-    font-size: 1.4rem;
+  line-height: 1.9em;
+  font-weight: 400;
+  font-size: 1.4rem;
 }
 
 .post .post-footer {
@@ -442,10 +442,10 @@ aside {
 }
 
 .post .post-footer .meta .info {
-    float: left;
-    font-size: 1.2rem;
-    margin-bottom: 1em;
-    color: var(--body-color);
+  float: left;
+  font-size: 1.2rem;
+  margin-bottom: 1em;
+  color: var(--body-color);
 }
 
 .post .post-footer .info .separator a {
@@ -502,8 +502,8 @@ aside {
 }
 
 .post .post-footer .tags {
-    padding-bottom: 15px;
-    font-size: 1.3rem;
+  padding-bottom: 15px;
+  font-size: 1.3rem;
 }
 
 .post .post-footer .tags ul {
@@ -605,15 +605,15 @@ aside {
 }
 
 .footer {
-    clear: both;
-    text-align: center;
-    font-size: 1rem;
-    margin: 0 auto;
-    bottom: 0;
-    width: 100%;
-    padding-bottom: 20px;
-    flex: 0;
-    position: relative;
+  clear: both;
+  text-align: center;
+  font-size: 1rem;
+  margin: 0 auto;
+  bottom: 0;
+  width: 100%;
+  padding-bottom: 20px;
+  flex: 0;
+  position: relative;
 }
 
 .footer a {
@@ -642,9 +642,9 @@ aside {
 }
 
 .list-with-title {
-    font-size: 1.4rem;
-    margin: 30px;
-    padding: 0;
+  font-size: 1.4rem;
+  margin: 30px;
+  padding: 0;
 }
 
 .list-with-title li {
@@ -653,10 +653,10 @@ aside {
 }
 
 .list-with-title .listing-title {
-    font-size: 2.4rem;
-    color: #666666;
-    font-weight: 600;
-    line-height: 2.2em;
+  font-size: 2.4rem;
+  color: #666666;
+  font-weight: 600;
+  line-height: 2.2em;
 }
 
 .list-with-title .listing {
@@ -700,9 +700,9 @@ aside {
 }
 
 .evernote a {
-    color: #fff;
-    padding: 11px;
-    font-size: 1.2rem;
+  color: #fff;
+  padding: 11px;
+  font-size: 1.2rem;
 }
 
 .evernote a:hover {
@@ -750,7 +750,7 @@ aside {
 }
 
 .about h3 {
-    font-size: 2.2rem;
+  font-size: 2.2rem;
 }
 
 /* links*/
@@ -759,7 +759,7 @@ aside {
 }
 
 .links h3 {
-    font-size: 2.2rem;
+  font-size: 2.2rem;
 }
 
 .links a {
@@ -776,7 +776,7 @@ aside {
 }
 
 .read_more {
-    font-size: 1.4rem;
+  font-size: 1.4rem;
 }
 
 .back-button {
@@ -802,37 +802,37 @@ a.btn {
 }
 
 .btn {
-    display: inline-block;
-    position: relative;
-    outline: 0;
-    color: var(--post-color);
-    background: transparent;
-    font-size: 1.4rem;
-    text-align: center;
-    text-decoration: none;
-    cursor: pointer;
-    border: 1px solid var(--border-color);
-    white-space: nowrap;
-    font-weight: 400;
-    font-style: normal;
-    border-radius: 999em;
+  display: inline-block;
+  position: relative;
+  outline: 0;
+  color: var(--post-color);
+  background: transparent;
+  font-size: 1.4rem;
+  text-align: center;
+  text-decoration: none;
+  cursor: pointer;
+  border: 1px solid var(--border-color);
+  white-space: nowrap;
+  font-weight: 400;
+  font-style: normal;
+  border-radius: 999em;
 }
 
 .btn:hover {
-    display: inline-block;
-    position: relative;
-    outline: 0px;
-    color: #464545;
-    background: transparent;
-    font-size: 1.4rem;
-    text-align: center;
-    text-decoration: none;
-    cursor: pointer;
-    border: 1px solid #464545;
-    white-space: nowrap;
-    font-weight: 400;
-    font-style: normal;
-    border-radius: 999em;
+  display: inline-block;
+  position: relative;
+  outline: 0px;
+  color: #464545;
+  background: transparent;
+  font-size: 1.4rem;
+  text-align: center;
+  text-decoration: none;
+  cursor: pointer;
+  border: 1px solid #464545;
+  white-space: nowrap;
+  font-weight: 400;
+  font-style: normal;
+  border-radius: 999em;
 }
 
 [role='back'] {
@@ -870,40 +870,40 @@ a.btn {
 }
 
 .menu .btn-down li a {
-    display: inline-block;
-    position: relative;
-    padding: 0.5em 1.25em;
-    outline: 0;
-    color: var(--post-color);
-    background: transparent;
-    font-size: 1.4rem;
-    text-align: center;
-    text-decoration: none;
-    cursor: pointer;
-    border: 1px solid var(--border-color);
-    white-space: nowrap;
-    font-weight: 400;
-    font-style: normal;
-    border-radius: 999em;
-    margin-top: 5px;
+  display: inline-block;
+  position: relative;
+  padding: 0.5em 1.25em;
+  outline: 0;
+  color: var(--post-color);
+  background: transparent;
+  font-size: 1.4rem;
+  text-align: center;
+  text-decoration: none;
+  cursor: pointer;
+  border: 1px solid var(--border-color);
+  white-space: nowrap;
+  font-weight: 400;
+  font-style: normal;
+  border-radius: 999em;
+  margin-top: 5px;
 }
 
 .menu .btn-down li a:hover {
-    position: relative;
-    padding: 0.5em 1.25em;
-    outline: 0;
-    color: #fff;
-    background: #3CBD10;
-    font-size: 1.4rem;
-    text-align: center;
-    text-decoration: none;
-    cursor: pointer;
-    border: 1px solid rgba(0, 0, 0, 0.15);
-    white-space: nowrap;
-    font-weight: 400;
-    font-style: normal;
-    border-radius: 999em;
-    margin-top: 5px;
+  position: relative;
+  padding: 0.5em 1.25em;
+  outline: 0;
+  color: #fff;
+  background: #3cbd10;
+  font-size: 1.4rem;
+  text-align: center;
+  text-decoration: none;
+  cursor: pointer;
+  border: 1px solid rgba(0, 0, 0, 0.15);
+  white-space: nowrap;
+  font-weight: 400;
+  font-style: normal;
+  border-radius: 999em;
+  margin-top: 5px;
 }
 
 .menu .btn-down div {
@@ -931,18 +931,18 @@ a.btn {
     padding-right: 20px;
   }
 
-    .sidebar__content {
-        display: flex;
-        flex-direction: column;
-        justify-content: center;
-        flex-grow: 1;
-    }
-    
-    .navbar {
-        display: flex;
-        flex-direction: column;
-        justify-content: space-between;
-    }
+  .sidebar__content {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    flex-grow: 1;
+  }
+
+  .navbar {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+  }
 
   .navbar {
     display: flex;
@@ -989,9 +989,9 @@ a.btn {
     height: 100px;
   }
 
-    .sidebar .logo-title .title h1 {
-        font-size: 2.2rem;
-    }
+  .sidebar .logo-title .title h1 {
+    font-size: 2.2rem;
+  }
 
   header {
     width: 100%;
@@ -1187,15 +1187,15 @@ a.btn {
   min-height: 35px;
 }
 .form-style ul li .field-style {
-    box-sizing: border-box; 
-    -webkit-box-sizing: border-box;
-    -moz-box-sizing: border-box; 
-    font-size: 1.4rem;
-    padding: 8px;
-    outline: none;
-    background-color: var(--bg-color);
-    border: 1px solid var(--form-border-color);
-    color: var(--body-color);
+  box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  font-size: 1.4rem;
+  padding: 8px;
+  outline: none;
+  background-color: var(--bg-color);
+  border: 1px solid var(--form-border-color);
+  color: var(--body-color);
 }
 .form-style ul li .field-style:focus {
   box-shadow: 0 0 5px;

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -1,19 +1,13 @@
-<div
-  class="sidebar{{ with .Site.Params.doNotLoadAnimations }}
-    .
-
-  {{ else }}
-    animated fadeInDown
-
-  {{ end }}"
->
-  <div class="sidebar__content">
-    <div class="logo-title">
-      <div class="title">
-        <img src="{{ .Site.Params.profilePicture | relURL }}" alt="profile picture" />
-        <h3 title=""><a href="/">{{ .Site.Params.Title }}</a></h3>
-        <div class="description">
-          <p>{{ replace .Site.Params.description "\n" "<br />" | safeHTML }}</p>
+<div class="sidebar{{ with .Site.Params.doNotLoadAnimations }} . {{ else }} animated fadeInDown {{ end }}">
+    <div class="sidebar__content">
+        <div class="logo-title">
+            <div class="title">
+                <img src="{{ .Site.Params.profilePicture | relURL }}" alt="profile picture">
+                <h1><a href="/">{{ .Site.Params.Title }}</a></h1>
+                <div class="description">
+                    <p>{{ replace .Site.Params.description "\n" "<br>" | safeHTML }}</p>
+                </div>
+            </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Yet there are no code style guidelines. Working in an environment of different contributors, this results in a lot of unformatted or differently formatted code in the repository. This PR aims to solve this by enforcing a common code style which should later be continued with a CI pipeline that formats PRs and the `master` branch automatically..

Be aware that to allow formatting of hugo templating, the plugin [prettier-plugin-go-template](https://github.com/NiklasPor/prettier-plugin-go-template) is used. As you can see, it itself is in early development. Using the latest beta, we are able to format all files except for `contact.html` which I put into `.prettierignore` for the time being.

For this to work, you need the [VSCode plugin for prettier](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) and install the dependencies from `package.lock.json` using npm/yarn or similar package manager. While the plugin comes with `prettier` built-in, it first looks for prettier installed locally within `node_modules`. It indeed is important to use the one defined in `package.json` to achieve a reproducable result. In fact, [prettier-plugin-go-template](https://github.com/NiklastsPor/prettier-plugin-go-template) currently has issues with the latest `"prettier": "2.3.*"`. This is why I pinned `"prettier": "~2.2.1"`.

The `package.json` also contains a quick script to format all files which can be used with `npm run prettier`.