### PR TITLE
fix: sidebar url

### DIFF
--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -11,7 +11,7 @@
     <div class="logo-title">
       <div class="title">
         <img src="{{ .Site.Params.profilePicture | relURL }}" alt="profile picture" />
-        <h3 title=""><a href="/">{{ .Site.Params.Title }}</a></h3>
+        <h3 title=""><a href="{{ .Site.BaseURL | relURL }}">{{ .Site.Params.Title }}</a></h3>
         <div class="description">
           <p>{{ replace .Site.Params.description "\n" "<br />" | safeHTML }}</p>
         </div>


### PR DESCRIPTION
makes the sidebar url follow the baseURL option in the config.toml. if
baseURL is configured as "https://domain.tld/blog", `<a href="/">` points
to "https://domain.tld". This commit changes that behaviour so it points
to the baseURL; in the above example, it would be `<a href="/blog">`.