### PR TITLE
border under h1 and toc

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -351,6 +351,7 @@ aside {
   font-size: 3em;
   letter-spacing: 1px;
   line-height: 1;
+  border-bottom: 1px solid var(--border-color);
 }
 
 .post .post-title h2 {
@@ -915,6 +916,7 @@ a.btn {
 #TableOfContents {
   display: block;
   background: transparent;
+  border-bottom: 1px solid var(--border-color);
 }
 
 #TableOfContents ul {


### PR DESCRIPTION
Adds a single pixel bottom border under the H1 heading and the toc (when enabled) to help distinguish the areas of the page.
This is the same border at the bottom of the page and that separates the posts on the homepage.