### PR TITLE
fix: if condition with gtagId

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -34,7 +34,7 @@
 {{- partial "medium-zoom.html" .context -}}
 {{- partial "math.html" .context -}}
 {{- template "_internal/google_analytics_async.html" .context -}}
-{{- if and (hugo.IsProduction) (.Site.Params.gtagId) -}}
+{{- if and (hugo.IsProduction) (.context.Site.Params.gtagId) -}}
   {{ partial "google-analytics-gtag-async.html" .context }}
 
 


### PR DESCRIPTION
Since the site variables are passed with the key `context` in a dictionary, the if condition `.Site.Params.gtagId` should be modified to `.context.Site.Params.gtagId` to check the gtagId properly.

Related to issue #228. 