### PR TITLE
Adding series to the theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -640,7 +640,7 @@ Please note that only "## H2 Headings" and "### H3 Headings" will appear in the 
 
 ### Enabling Series
 
-You can enable series to which allows to split up a huge post into a set of multiple blog posts that are still linked. This would also provide a unique link to the full series of blogposts.
+You can enable series which allows to split up a huge post into a set of multiple blog posts that are still linked. This would also provide a unique link to the full series of blogposts. Each individual post in the series will also contain links to the other parts under the heading `See Also`.
 
 First we need to enable the `series` taxonomy in the config.
 

--- a/README.md
+++ b/README.md
@@ -654,8 +654,7 @@ First, we need to enable the `series` taxonomy in the config.
 With this enabled, we can now proceed to specify the series in the Front Matter of each post of that series.
 
 ```md
-series:
-    - series-name
+series: - series-name
 ```
 
 If you want to share the full series, you can do so by sharing the link `<base-url>/series/<series-name>`

--- a/README.md
+++ b/README.md
@@ -640,9 +640,9 @@ Please note that only "## H2 Headings" and "### H3 Headings" will appear in the 
 
 ### Enabling Series
 
-You can enable series which allows to split up a huge post into a set of multiple blog posts that are still linked. This would also provide a unique link to the full series of blogposts. Each individual post in the series will also contain links to the other parts under the heading `Posts in this Series`.
+You can enable series, which allows splitting up a huge post into a set of multiple blog posts that are still linked. This would also provide a unique link to the full series of blog posts. Each individual post in the series will also contain links to the other parts under the heading `Posts in this Series`.
 
-First we need to enable the `series` taxonomy in the config.
+First, we need to enable the `series` taxonomy in the config.
 
 ```toml
 [taxonomies]
@@ -651,14 +651,14 @@ First we need to enable the `series` taxonomy in the config.
     tag = "tags"
 ```
 
-With this enabled we can now proceed to specify the series in the Front Matter of each post of that series.
+With this enabled, we can now proceed to specify the series in the Front Matter of each post of that series.
 
 ```md
 series:
     - series-name
 ```
 
-If you know want to share the full series you can do so by sharing the link `<base-url>/series/series-name>`
+If you want to share the full series, you can do so by sharing the link `<base-url>/series/<series-name>`
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -640,7 +640,7 @@ Please note that only "## H2 Headings" and "### H3 Headings" will appear in the 
 
 ### Enabling Series
 
-You can enable series which allows to split up a huge post into a set of multiple blog posts that are still linked. This would also provide a unique link to the full series of blogposts. Each individual post in the series will also contain links to the other parts under the heading `See Also`.
+You can enable series which allows to split up a huge post into a set of multiple blog posts that are still linked. This would also provide a unique link to the full series of blogposts. Each individual post in the series will also contain links to the other parts under the heading `Posts in this Series`.
 
 First we need to enable the `series` taxonomy in the config.
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Anatole's aims to be minimalistic and sleek but still brings some great function
 - Compliant to strict CSP
 - Syntax highlighting
 - Uses Hugo pipes to process assets
+- Series
 
 ## Preview the exampleSite
 
@@ -636,6 +637,28 @@ toc = true
 ```
 
 Please note that only "## H2 Headings" and "### H3 Headings" will appear in the table of contents.
+
+### Enabling Series
+
+You can enable series to which allows to split up a huge post into a set of multiple blog posts that are still linked. This would also provide a unique link to the full series of blogposts.
+
+First we need to enable the `series` taxonomy in the config.
+
+```toml
+[taxonomies]
+    category = "categories"
+    series = "series"
+    tag = "tags"
+```
+
+With this enabled we can now proceed to specify the series in the Front Matter of each post of that series.
+
+```md
+series:
+    - series-name
+```
+
+If you know want to share the full series you can do so by sharing the link `<base-url>/series/series-name>`
 
 ## License
 

--- a/exampleSite/config/_default/config.toml
+++ b/exampleSite/config/_default/config.toml
@@ -22,3 +22,8 @@ pygmentsCodefencesGuessSyntax = true
     [markup.goldmark]
         [markup.goldmark.renderer]
         unsafe=true
+
+[taxonomies]
+    category = "categories"
+    series = "series"
+    tag = "tags"

--- a/exampleSite/content/english/post/series-part-1.md
+++ b/exampleSite/content/english/post/series-part-1.md
@@ -37,4 +37,4 @@ series:
 ---
 ```
 
-Each individual post will now also show the other posts in the series under the `See Also` heading.
+Each individual post will now also show the other posts in the series under the `Posts in this Series` heading.

--- a/exampleSite/content/english/post/series-part-1.md
+++ b/exampleSite/content/english/post/series-part-1.md
@@ -1,0 +1,40 @@
+---
+author: Hugo Authors
+title: Series Part 1
+date: 2021-08-14
+description: A brief guide to how to setup series part 1
+series:
+    - series-setup
+---
+
+In this first part of the series we'll show you how to create a series
+
+<!--more-->
+
+As a first step we need to add series as a taxonomy. We can do this by editing the `config.toml`.  
+Note: We always need to define the existing taxonomies as well.
+
+```toml
+[taxonomies]
+    category = "categories"
+    series = "series"
+    tag = "tags"
+```
+Now we have the series enabled, the next thing we need to do is add the series name in the FrontMatter.
+For our example we'll use this post and the next part.  
+
+As you can see we've set the series to `series-setup`. We also do the same in the next parts of the series.  
+This end results should be a Front Matter that looks similar to this:
+
+```md
+---
+author: Hugo Authors
+title: Series Part 1
+date: 2021-08-14
+description: A brief guide to how to setup series part 1
+series:
+    - series-setup
+---
+```
+
+Each individual post will now also show the other posts in the series under the `See Also` heading.

--- a/exampleSite/content/english/post/series-part-1.md
+++ b/exampleSite/content/english/post/series-part-1.md
@@ -4,7 +4,7 @@ title: Series Part 1
 date: 2021-08-14
 description: A brief guide to how to setup series part 1
 series:
-    - series-setup
+  - series-setup
 ---
 
 In this first part of the series we'll show you how to create a series
@@ -20,8 +20,9 @@ Note: We always need to define the existing taxonomies as well.
     series = "series"
     tag = "tags"
 ```
+
 Now we have the series enabled, the next thing we need to do is add the series name in the FrontMatter.
-For our example we'll use this post and the next part.  
+For our example we'll use this post and the next part.
 
 As you can see we've set the series to `series-setup`. We also do the same in the next parts of the series.  
 This end results should be a Front Matter that looks similar to this:
@@ -33,7 +34,7 @@ title: Series Part 1
 date: 2021-08-14
 description: A brief guide to how to setup series part 1
 series:
-    - series-setup
+  - series-setup
 ---
 ```
 

--- a/exampleSite/content/english/post/series-part-2.md
+++ b/exampleSite/content/english/post/series-part-2.md
@@ -4,7 +4,7 @@ title: Series Part 2
 date: 2021-08-15
 description: A brief guide to how to setup series part 2
 series:
-    - series-setup
+  - series-setup
 ---
 
 In this second part of the series we'll show you where to find the full series
@@ -12,6 +12,6 @@ In this second part of the series we'll show you where to find the full series
 <!--more-->
 
 When you created a series, you'll probably want to link to the full set of blogposts.  
-In this example we used `series-setup` as our series name.  
+In this example we used `series-setup` as our series name.
 
 This means we can now go to `http://localhost:1313/series/series-setup/` to see all the blog posts of this serie.

--- a/exampleSite/content/english/post/series-part-2.md
+++ b/exampleSite/content/english/post/series-part-2.md
@@ -1,0 +1,17 @@
+---
+author: Hugo Authors
+title: Series Part 2
+date: 2021-08-15
+description: A brief guide to how to setup series part 2
+series:
+    - series-setup
+---
+
+In this second part of the series we'll show you where to find the full series
+
+<!--more-->
+
+When you created a series, you'll probably want to link to the full set of blogposts.  
+In this example we used `series-setup` as our series name.  
+
+This means we can now go to `http://localhost:1313/series/series-setup/` to see all the blog posts of this serie.

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -45,16 +45,10 @@
 
       {{ .Content }}
 
-      {{ if isset .Params "series" }}
-        {{$related := where .Site.RegularPages ".Params.series" "intersect" .Params.series }}
+      {{- if isset .Params "series" -}}
+        {{- partial "series.html" . -}}  
 
-          <h3>Posts in this Series</h3>
-          <ul>
-            {{ range $related }}
-                <li><a href="{{ .Page.RelPermalink }}">{{ .Page.Title }}</a></li>
-            {{ end }}
-          </ul>
-      {{ end }}
+      {{- end -}}
 
       {{- if (eq .Params.contact true) -}}
         {{- partial "contact.html" . -}}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -46,7 +46,7 @@
       {{ .Content }}
 
       {{- if isset .Params "series" -}}
-        {{- partial "series.html" . -}}  
+        {{- partial "series.html" . -}}
 
       {{- end -}}
 

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -45,6 +45,17 @@
 
       {{ .Content }}
 
+      {{ if isset .Params "series" }}
+        {{$related := where .Site.RegularPages ".Params.series" "intersect" .Params.series }}
+
+          <h3>Posts in this Series</h3>
+          <ul>
+            {{ range $related }}
+                <li><a href="{{ .Page.RelPermalink }}">{{ .Page.Title }}</a></li>
+            {{ end }}
+          </ul>
+      {{ end }}
+
       {{- if (eq .Params.contact true) -}}
         {{- partial "contact.html" . -}}
 

--- a/layouts/partials/series.html
+++ b/layouts/partials/series.html
@@ -1,8 +1,10 @@
-{{$related := where .Site.RegularPages ".Params.series" "intersect" .Params.series }}
+{{ $related := where .Site.RegularPages ".Params.series" "intersect" .Params.series }}
+
 
 <h3>Posts in this Series</h3>
 <ul>
-{{ range $related }}
+  {{ range $related }}
     <li><a href="{{ .Page.RelPermalink }}">{{ .Page.Title }}</a></li>
-{{ end }}
+
+  {{ end }}
 </ul>

--- a/layouts/partials/series.html
+++ b/layouts/partials/series.html
@@ -1,0 +1,8 @@
+{{$related := where .Site.RegularPages ".Params.series" "intersect" .Params.series }}
+
+<h3>Posts in this Series</h3>
+<ul>
+{{ range $related }}
+    <li><a href="{{ .Page.RelPermalink }}">{{ .Page.Title }}</a></li>
+{{ end }}
+</ul>


### PR DESCRIPTION
This merge request is based on the issue #234 

I've added the following things to make the series work in the theme:

- Example site: Add 2 blog posts which are part of the same series, these also describe how it works
- Config: Add the series taxonomy
- README: Add the section on how to enable series
- layouts/partials/series.html: Add a new partial to display all the posts in the series.
- layouts/_default/single.html: Introduce the new partial that will show the `Posts in this series`

I've tested the functionality with the 2 example site blog posts.

Since there is no real style guide I was unsure where to place the functionality inside the single so I added it where I think it fits best. Let me know if you would like it in a different location!

I also noticed the Table of Contents is not translated so I did not translate the `Posts in this series` either. Though I could create another translation MR for all of that OR add the translation for `Posts in this series` in this MR. However, I do not have knowledge over all of the languages so some would be Google Translate or defaulting in English.

Hope this helps! Let me know if there is anything wrong or if you have questions!

![Screenshot 2021-08-15 at 11 33 36](https://user-images.githubusercontent.com/1481082/129474086-41163d22-55a0-4ffe-96db-7aa335a9a1f3.png)
![Screenshot 2021-08-15 at 11 33 47](https://user-images.githubusercontent.com/1481082/129474089-1f436c16-5978-41b8-93f0-5164073422ad.png)
![Screenshot 2021-08-15 at 11 33 55](https://user-images.githubusercontent.com/1481082/129474090-5b5f1803-8bd5-47dd-9aab-ef2599661c39.png)
