### PR TITLE
Language dropdown

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -270,6 +270,80 @@ aside {
   width: var(--sidebar-width);
 }
 
+/*
+Language Switch
+*/
+
+.sl-nav {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  position: relative;
+  display: inline-block;
+}
+.sl-nav li {
+  cursor: pointer;
+  padding-bottom: 10px;
+}
+.sl-nav li ul {
+  display: none;
+}
+.sl-nav li:hover ul {
+  position: absolute;
+  top: 29px;
+  right: -15px;
+  display: block;
+  background: #fff;
+  padding-left: 0;
+  padding-top: 0px;
+  z-index: 1;
+  border-radius: 5px;
+  box-shadow: 0px 0px 20px rgba(0, 0, 0, 0.2);
+}
+.sl-nav li:hover .triangle {
+  position: absolute;
+  top: 15px;
+  right: -10px;
+  z-index: 10;
+  height: 14px;
+  overflow: hidden;
+  width: 30px;
+  background: transparent;
+}
+.sl-nav li:hover .triangle:after {
+  content: '';
+  display: block;
+  z-index: 20;
+  width: 15px;
+  transform: rotate(45deg) translateY(0px) translatex(10px);
+  height: 15px;
+  background: #fff;
+  border-radius: 2px 0px 0px 0px;
+  box-shadow: 0px 0px 20px rgba(0, 0, 0, 0.2);
+}
+.sl-nav li ul li {
+  position: relative;
+  text-align: left;
+  background: transparent;
+  padding: 15px 15px;
+  padding-bottom: 0;
+  z-index: 2;
+  font-size: 15px;
+  color: #3c3c3c;
+  display: block;
+}
+.sl-nav li ul li:last-of-type {
+  padding-bottom: 15px;
+}
+.sl-nav li ul li span {
+  padding-left: 5px;
+}
+.sl-nav li ul li span:hover,
+.sl-nav li ul li span.active {
+  color: var(--tag-color);
+}
+
+
 .sidebar {
   -webkit-background-size: cover;
   background-size: cover;
@@ -340,6 +414,8 @@ aside {
 .sidebar .social-links a:hover {
   color: #2660ab;
 }
+
+
 
 .post {
   background-color: var(--bg-color);

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -287,12 +287,9 @@ Language Switch
 }
 .sl-nav li ul {
   display: none;
-}
-.sl-nav li:hover ul {
   position: absolute;
   top: 29px;
   right: -15px;
-  display: block;
   background: #fff;
   padding-left: 0;
   padding-top: 0px;
@@ -300,7 +297,7 @@ Language Switch
   border-radius: 5px;
   box-shadow: 0px 0px 20px rgba(0, 0, 0, 0.2);
 }
-.sl-nav li:hover .triangle {
+.sl-nav li .triangle {
   position: absolute;
   top: 15px;
   right: -10px;
@@ -310,9 +307,9 @@ Language Switch
   width: 30px;
   background: transparent;
 }
-.sl-nav li:hover .triangle:after {
+.sl-nav li .triangle:after {
   content: '';
-  display: block;
+  display: block; /* Weird behavior on mobile? */ 
   z-index: 20;
   width: 15px;
   transform: rotate(45deg) translateY(0px) translatex(10px);

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -335,9 +335,6 @@ Language Switch
 .sl-nav li ul li:last-of-type {
   padding-bottom: 15px;
 }
-.sl-nav li ul li span {
-  padding-left: 5px;
-}
 .sl-nav li ul li span:hover,
 .sl-nav li ul li span.active {
   color: var(--tag-color);

--- a/assets/js/anatole-language-dropdown.js
+++ b/assets/js/anatole-language-dropdown.js
@@ -1,0 +1,37 @@
+
+
+
+function setDisplay(elements, value) {
+    elements.forEach(element => {
+        element.style.display = value;
+    });
+}
+
+var isDropdownShowing = false;
+
+function toggleDropdown() {
+    var displayVal = isDropdownShowing ? 'none' : 'block';
+    isDropdownShowing = !isDropdownShowing;
+
+    setDisplay(document.querySelectorAll('.sl-nav li ul'), displayVal);
+    setDisplay(document.querySelectorAll('.sl-nav li ul li'), displayVal);
+    setDisplay(document.querySelectorAll('.sl-nav li .triangle'), displayVal);
+}
+
+
+// Add listener after page loads
+document.addEventListener(
+    'DOMContentLoaded',
+    function () {
+    document.querySelector('ul[class="sl-nav"]').addEventListener('click', function() {toggleDropdown();}, false);
+
+    // window.onclick = function(event) {
+    //     if (!event.target.matches('ul[class="sl-nav"]')) {
+    //         isDropdownShowing = true;   // TODO: change implmentation
+    //         toggleDropdown();
+    //     }
+    // }
+    },
+    false,
+  );
+

--- a/assets/js/anatole-language-dropdown.js
+++ b/assets/js/anatole-language-dropdown.js
@@ -23,6 +23,9 @@ function toggleDropdown() {
 document.addEventListener(
     'DOMContentLoaded',
     function () {
+    // Triangle should be hidden on page load
+    setDisplay(document.querySelectorAll('.sl-nav li .triangle'), 'none');
+
     document.querySelector('ul[class="sl-nav"]').addEventListener('click', function() {toggleDropdown();}, false);
 
     // window.onclick = function(event) {

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -139,6 +139,15 @@
 
   {{ end }}
 
+  {{ $anatoleLanguageDropdown := resources.Get "js/anatole-language-dropdown.js" }}
+  {{ $secureLanguageDropdownJS := $anatoleLanguageDropdown |  resources.Minify | resources.Fingerprint }}
+  <script
+    type="text/javascript"
+    src="{{ $secureLanguageDropdownJS.RelPermalink }}"
+    integrity="{{ $secureLanguageDropdownJS.Data.Integrity }}"
+    crossorigin="anonymous"
+  ></script>
+
   {{- $js := "" -}}
   {{- range .Site.Params.customJs -}}
     {{- if or (in . "http://") (in . "https://") -}}

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -35,8 +35,9 @@
           </li>
 
         {{ end }}
-        <li>
-          {{ if and .Site.IsMultiLingual }}
+      </div>
+      <li>
+        {{ if and .Site.IsMultiLingual }}
             <ul class="sl-nav" aria-label="Language switcher">
               <li>
                 <b>{{ .Site.Language.LanguageName }}</b> <i class="fa fa-angle-down" aria-hidden="true"></i>
@@ -61,11 +62,7 @@
                 </ul>
               </li>
             </ul>
-
           {{ end }}
-        </li>
-      </div>
-      <li>
         {{ if not .Site.Params.disableThemeSwitcher }}
           <a class="theme-switch" title="Switch Theme">
             <i class="fas fa-adjust fa-fw" aria-hidden="true"></i>

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -35,14 +35,35 @@
           </li>
 
         {{ end }}
-        {{ if .Site.IsMultiLingual }}
-          {{ range $.Site.Home.AllTranslations }}
-            <li><a href="{{ .RelPermalink }}" title="{{ .Language.LanguageName }}">{{ .Language.LanguageName }}</a></li>
+        <li>
+          {{ if and .Site.IsMultiLingual }}
+            <ul class="sl-nav" aria-label="Language switcher">
+              <li>
+                <b>{{ .Site.Language.LanguageName }}</b> <i class="fa fa-angle-down" aria-hidden="true"></i>
+                <div class="triangle"></div>
+                <ul>
+                  {{ range $.Translations }}
+
+                    <li>
+                      <a href="{{ .RelPermalink }}" title="{{ .Language.LanguageName }}"
+                        ><span
+                          {{ if eq . $.Site.Language }}
+                            class="active"
+
+                          {{ end }}
+                          aria-label="{{ i18n "ariaLanguage" }}{{ .Language.LanguageName }}"
+                          >{{ .Language.LanguageName }}</span
+                        ></a
+                      >
+                    </li>
+
+                  {{ end }}
+                </ul>
+              </li>
+            </ul>
 
           {{ end }}
-
-
-        {{ end }}
+        </li>
       </div>
       <li>
         {{ if not .Site.Params.disableThemeSwitcher }}


### PR DESCRIPTION
Still a WIP

Tasks
- [x] Have the dropdown show up on click rather than on hover
- [x] Fix bug where dropdown triangle will show up before click on mobile only
        _Fixed, sort of - the JS sets the display attribute on page load to hide the triangle. Proper fix would be to fix it in CSS._
- [x] Move the language navbar item to the right of the navbar, instead of next to the navigational links on desktop. The language navbar item should be located on the left of the theme switcher button.
- [ ] Proper styling on mobile
  - [ ] Language switcher text is too big
  - [ ] The dropdown overlaps the language switcher button
- [ ] On clicking anywhere outside of the dropdown, the dropdown should be dismissed. There is some commented out code in the JS file that attempts to do this but it's broken and will cancel out with the code that toggles the dropdown in the first place, which results in no dropdown at all.
- [ ] Fix dropdown text color in dark mode (text is too grey)

Will close #169 