### PR TITLE
Redirect users to home page of current language

### DIFF
--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -11,7 +11,7 @@
     <div class="logo-title">
       <div class="title">
         <img src="{{ .Site.Params.profilePicture | relURL }}" alt="profile picture" />
-        <h3 title=""><a href="{{ .Site.BaseURL | relURL }}">{{ .Site.Params.Title }}</a></h3>
+        <h3 title=""><a href="{{ .Site.BaseURL | relLangURL }}">{{ .Site.Params.Title }}</a></h3>
         <div class="description">
           <p>{{ replace .Site.Params.description "\n" "<br />" | safeHTML }}</p>
         </div>


### PR DESCRIPTION
Quick fix for the URL under the profile picture in the left sidebar redirecting to the main homepage of the website, instead of the home page of the currently selected language.