### PR TITLE
fix: language dropdown styling

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -324,7 +324,6 @@ Language Switch
   padding-bottom: 15px;
 }
 .sl-nav li .dropdown li span {
-  padding-left: 5px;
   font-size: 1.3rem;
   white-space: nowrap;
 }

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -326,6 +326,7 @@ Language Switch
 .sl-nav li .dropdown li span {
   padding-left: 5px;
   font-size: 1.3rem;
+  white-space: nowrap;
 }
 .sl-nav li .dropdown li span.active {
   color: var(--tag-color);


### PR DESCRIPTION
@lxndrblz sorry about the multiple pull requests! Hopefully this is one of the last ones regarding the dropdown.

Before:
![image](https://user-images.githubusercontent.com/13326074/140544090-3506b1c5-08d8-4065-90b0-606dfa89137a.png)
After:
![image](https://user-images.githubusercontent.com/13326074/140544149-a0e34c16-eb49-46af-b56b-908e39139114.png)

Actually for the second commit is there a reason for the 5px padding on the left? Please let me know if I'm missing anything here and I'll drop the commit.