### PR TITLE
Make Canoncial Link Absolute

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -116,7 +116,7 @@
   <link rel="icon" type="image/png" sizes="32x32" href="{{ .Site.Params.favicon | relURL }}favicon-32x32.png" />
   <link rel="icon" type="image/png" sizes="16x16" href="{{ .Site.Params.favicon | relURL }}favicon-16x16.png" />
 
-  <link rel="canonical" href="{{ .RelPermalink }}" />
+  <link rel="canonical" href="{{ .Permalink }}" />
 
   <!-- RSS -->
   {{ with .OutputFormats.Get "rss" -}}


### PR DESCRIPTION
Currently, the canonical link is set relative to the page root which is a major [SEO issue](https://web.dev/canonical/?utm_source=lighthouse&utm_medium=devtools).

```
<link rel="canonical" href="{{ .RelPermalink }}" />
```

This PR fixes this and brings the lighthouse score back on track. :dash: 