### PR TITLE
Add .devcontainer directory to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ demo/
 !.hugo/version
 .hugo_build.lock
 /node_modules
+.devcontainer


### PR DESCRIPTION
As I, and maybe others too, like developing in VSCode Devcontainers, I added the folder to `.gitignore`.

I guess it makes even more sense to ignore than to share `.devcontainer` allowing each user have their own local configuration.