### PR TITLE
Fix Language Picker Styling on Mobile

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -311,15 +311,12 @@ Language Switch
   position: relative;
   text-align: left;
   background: transparent;
-  padding: 15px 15px;
-  padding-bottom: 0;
+  padding: 12px;
   z-index: 2;
   color: #3c3c3c;
   display: block;
 }
-.sl-nav li .dropdown li:last-of-type {
-  padding-bottom: 15px;
-}
+
 .sl-nav li .dropdown li span {
   font-size: 1.3rem;
   white-space: nowrap;

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -318,7 +318,6 @@ Language Switch
 }
 
 .sl-nav li .dropdown li span {
-  font-size: 1.3rem;
   white-space: nowrap;
 }
 .sl-nav li .dropdown li span.active {
@@ -1280,7 +1279,7 @@ a.btn {
     position: relative;
     text-transform: uppercase;
     text-align: center;
-    font-size: 1.3em;
+    font-size: 1.6rem;
   }
 
   header .nav__list ul {
@@ -1371,7 +1370,7 @@ a.btn {
 
   .sl-nav li .dropdown li {
     text-align: center;
-    padding: initial;
+    padding: 0.5rem 0.75rem;
   }
 
   .sl-nav li .dropdown li span {


### PR DESCRIPTION
I found the styling of the language picker on mobile to be odd. This PR reworks this.

before:
![image](https://user-images.githubusercontent.com/35292572/146677436-d88dc154-277b-424e-bdb9-38027c3b9c3b.png)

after:
![image](https://user-images.githubusercontent.com/35292572/146677477-d69c18ae-09cd-48f3-9d34-477ed966c934.png)
