### PR TITLE
feat: Added page title switcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -743,6 +743,17 @@ portfolioitems:
 
 Please note that fields such as start, end, authors, and tags will only appear if they have been populated. The image path defined under `image` parameter is relative to the static folder, similarly to images included in the post.
 
+## Reverse Title
+
+By default the Window title is 'Author | Title' and if you would like to switch the two, you can do that by setting the parameter  `reversepagetitle = true` in `config.toml`
+
+
+```toml
+[params]
+reversepagetitle = true
+
+```
+
 ## License
 
 Anatole is licensed under the [MIT license](https://github.com/lxndrblz/anatole/blob/master/LICENSE).

--- a/README.md
+++ b/README.md
@@ -743,9 +743,9 @@ portfolioitems:
 
 Please note that fields such as start, end, authors, and tags will only appear if they have been populated. The image path defined under `image` parameter is relative to the static folder, similarly to images included in the post.
 
-## Reverse Title
+## Reverse Page Title
 
-By default the Window title is 'Author | Title' and if you would like to switch the two, you can do that by setting the parameter  `reversepagetitle = true` in `config.toml`
+By default the title of pages is `Author | PageTitle` and if you instead would like to switch the two to be `PageTitle | Author`, you can do that by setting the parameter  `reversepagetitle` to `true` in `config.toml`
 
 
 ```toml

--- a/README.md
+++ b/README.md
@@ -743,10 +743,9 @@ portfolioitems:
 
 Please note that fields such as start, end, authors, and tags will only appear if they have been populated. The image path defined under `image` parameter is relative to the static folder, similarly to images included in the post.
 
-## Reverse Page Title
+### Reverse Page Title
 
-By default the title of pages is `Author | PageTitle` and if you instead would like to switch the two to be `PageTitle | Author`, you can do that by setting the parameter  `reversepagetitle` to `true` in `config.toml`
-
+By default, the title of pages is `Author | PageTitle`. You can switch the order to `PageTitle | Author` by setting the parameter `reversepagetitle` to `true` in `config.toml`.
 
 ```toml
 [params]

--- a/exampleSite/config/_default/params.toml
+++ b/exampleSite/config/_default/params.toml
@@ -28,7 +28,7 @@ listDateFormat = "2/1/2006"
 # readMore = true
 # postSectionName = "blog"
 
-reversepagetitle = true # When set to 'true' the Window Title will be revesed to 'Title | Author' instead of default 'Author | Title'
+reversepagetitle = true # When set to 'true', the Window Title will be reversed to 'Title | Author' instead of the default 'Author | Title'
 
 [simpleAnalytics]
 # enable = true

--- a/exampleSite/config/_default/params.toml
+++ b/exampleSite/config/_default/params.toml
@@ -28,6 +28,7 @@ listDateFormat = "2/1/2006"
 # readMore = true
 # postSectionName = "blog"
 
+reversepagetitle = true # When set to 'true' the Window Title will be revesed to 'Title | Author' instead of default 'Author | Title'
 
 [simpleAnalytics]
 # enable = true

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,9 +1,17 @@
 <head>
   <title>
-    {{if (eq .Site.Params.reversepagetitle true)}}
-      {{ with .Title }}{{ . }} | {{ end }}{{ .Site.Params.author }}
+    {{ if (eq .Site.Params.reversepagetitle true) }}
+      {{ with .Title }}
+        {{ . }} |
+
+      {{ end }}{{ .Site.Params.author }}
+
     {{ else }}
-      {{ .Site.Params.author }}{{ with .Title }} | {{ . }} {{ end }}
+      {{ .Site.Params.author }}{{ with .Title }}
+        | {{ . }}
+
+      {{ end }}
+
     {{ end }}
   </title>
 

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,12 +1,10 @@
 <head>
   <title>
-    {{ .Site.Params.author }}{{ with .Title }}
-      |
-      {{ . }}
-
-
+    {{if (eq .Site.Params.reversepagetitle true)}}
+      {{ with .Title }}{{ . }} | {{ end }}{{ .Site.Params.author }}
+    {{ else }}
+      {{ .Site.Params.author }}{{ with .Title }} | {{ . }} {{ end }}
     {{ end }}
-
   </title>
 
   <!-- Meta -->


### PR DESCRIPTION
This PR enables to switch the page title to be: `PageTitle | Autor` instead of the default `Author | PageTitle`