### PR TITLE
Turn anatole theme into a hugo module

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,13 +52,41 @@ hugo server --themesDir ../..
 
 ## Quick Start
 
+### Route 1 (recommended): use theme as Hugo module
+
+1. Install prerequisites [git](https://git-scm.com/downloads) and [go](https://go.dev/dl/) (>= 1.12)
+2. Turn your Hugo Project into a Hugo module: `hugo mod init github.com/me/my-project`
+3. Declare the `Anatole` module as a dependency of your site: `hugo mod get github.com/lxndrblz/anatole`
+4. Add the following lines at the end of your `config.toml`:
+
+```
+[module]
+  # uncomment line below for temporary local development of module
+  # replacements = "github.com/lxndrblz/anatole -> ../../anatole"
+  [[module.imports]]
+    path = "github.com/lxndrblz/anatole"
+    disable = false
+```
+### Route 2 (traditional): install theme as Git submodule
+
 1. Add the repository into your Hugo Project repository as a submodule: `git submodule add https://github.com/lxndrblz/anatole.git themes/anatole`.
-2. Configure your `config.toml`. Feel free to copy the demo `config.toml` and some content from the exampleSite.
-3. Build your site with `hugo serve` and admire the result at `http://localhost:1313/`.
+
+### Start up your site
+
+1. Configure your `config.toml`. Feel free to copy the demo `config.toml` and some content from the exampleSite.
+2. Build your site with `hugo serve` and admire the result at `http://localhost:1313/`.
 
 ## Update your installation
 
-If you want to get the latest update of the `Anatole` theme, please execute this command:
+If you want to get the latest update of the `Anatole` theme, please follow the instructions below:
+
+### Theme as Hugo module
+
+```shell
+hugo mod get -u github.com/lxndrblz/anatole
+```
+
+### Theme as Git submodule
 
 ```shell
 git submodule update --remote --merge

--- a/exampleSite/config/_default/config.toml
+++ b/exampleSite/config/_default/config.toml
@@ -2,7 +2,12 @@ baseURL = "https://example.com"
 languageCode = "en"
 DefaultContentLanguage = "en"
 title = "Website of Jane Doe"
+
+# theme as hugo module
+#theme = "github.com/lxndrblz/anatole"
+# theme as git submodule
 theme = "anatole"
+
 summarylength = 10
 enableEmoji = true
 enableRobotsTXT = true

--- a/exampleSite/go.mod
+++ b/exampleSite/go.mod
@@ -1,0 +1,3 @@
+module github.com/lxndrblz/anatole-example
+
+go 1.17

--- a/exampleSite/go.mod
+++ b/exampleSite/go.mod
@@ -1,3 +1,3 @@
 module github.com/lxndrblz/anatole-example
 
-go 1.17
+go 1.12

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/lxndrblz/anatole
 
-go 1.17
+go 1.12

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/lxndrblz/anatole
+
+go 1.17


### PR DESCRIPTION
This PR turns the theme into a hugo module.
With `git`and `go` installed, making use of the anatole theme is now as easy as:

```
hugo new site my_site
cd mysite
echo 'theme = "github.com/lxndrblz/anatole"' >> config.toml
hugo server
```

Copying/cloning the theme in the themes folder is still possible of course.

If desired, I can extend the `Quickstart` section in `README.md`, explaining how to make use of the theme as module.