### PR TITLE
fix: [display] dark mode preference was not taken into account.

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -7,7 +7,7 @@
 >
   {{- partial "head.html" . -}}
   <body
-    {{ if eq .Params.displayMode "dark" }}
+    {{ if eq .Site.Params.displayMode "dark" }}
       class="body theme--dark"
 
     {{ else }}


### PR DESCRIPTION
## Description

When ```displayMode = "dark"``` is set in ```params``` the dark theme is still not the preferred.


### Issue Number:

- #318 

---

### Additional Information (Optional)

- _Here goes any Additional Information you would like to add._

---

### Checklist

The fix is so small. But I have checked it works.

---

### Testing Checklist

Yes, I ensured that all of the following scenarios were tested:

- [Yes] Desktop Light Mode (Default)
- [Yes] Desktop Dark Mode
- [Yes] Desktop Light RTL Mode
- [Yes] Desktop Dark RTL Mode
- [ Yes] Mobile Light Mode
- [Yes] Mobile Dark Mode
- [Yes] Mobile Light RTL Mode
- [Yes] Mobile Dark RTL Mode

---

### Notify the following users

- @lxndrblz 
