### PR TITLE
feat: add an affiliate link in posts to redirect to different websites

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -13,7 +13,7 @@
       {{ range .Pages }}
         <ul class="archive__list">
           <li class="archive__list-item">
-            <a class="archive__list-title" href="{{ .RelPermalink }}" title="{{ .Title }}">{{ .Title }}</a>
+            <a class="archive__list-title" href="{{ if .Params.affiliatelink }} {{ .Params.affiliatelink }} {{ else }} {{ .RelPermalink }} {{ end }}" title="{{ .Title }}">{{ .Title }}</a>
             <div class="archive__list-date">
               {{ if isset .Site.Params "listdateformat" }}
                 {{ .Date.Format .Site.Params.listDateFormat }}


### PR DESCRIPTION
## Description
Adds the ability to provide an affiliate link. This can be used to redirect from the website to another page. This is useful in cases where your blog is hosted on another website to which you want to redirect from your personal website.

### Issue Number:
NA

---

### Additional Information (Optional)
An `affiliatelink: "<URL to redirect to>"` can be provided in the `posts/*.md` file. If this is provided the content of the page is excluded and will be redirected to the webpage.

#### Usage example
content/posts/post-1.md
```
---
title: "OpenEBS NDM, go-to solution for managing Kubernetes Local Storage"
date: 2021-01-13T19:27:53+05:30
draft: false
categories:
- Tech
- Blog
tags:
- openebs
- kubernetes
- ndm
affiliatelink: "https://openebs.io/blog/openebs-ndm,-go-to-solution-for-managing-kubernetes-local-storage"
---
```
Affiliate link redirects to the blog that is published at a different source

---

### Checklist

Yes, I included all necessary artefacts, including:

- [ ] Tests
- [ ] Documentation
- [x] Implementation (Code and Ressources)
- [x] Example

---

### Testing Checklist

Yes, I ensured that all of the following scenarios were tested:

- [x] Desktop Light Mode (Default)
- [x] Desktop Dark Mode
- [ ] Desktop Light RTL Mode
- [ ] Desktop Dark RTL Mode
- [x] Mobile Light Mode
- [x] Mobile Dark Mode
- [ ] Mobile Light RTL Mode
- [ ] Mobile Dark RTL Mode

---

### Notify the following users
@lxndrblz 
