### PR TITLE
Set open graph meta tags without requiring series taxonomy

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -231,15 +231,7 @@
 
 
   <!-- Open Graph -->
-  {{- if isset .Site.Taxonomies "series" }}
-    {{- if not (eq (len .Site.Taxonomies.series) 0) -}}
-      {{ template "_internal/opengraph.html" . }}
-
-
-    {{- end -}}
-
-
-  {{- end }}
+  {{ template "_internal/opengraph.html" . }}
 
 
   <!-- Schema.org-->


### PR DESCRIPTION
## Description

Currently, Open Graph is only set when the `series` taxonomy is used. This is an inopportune default which this PR addresses.

Citing @Xen-Echo from #166:

> Testing locally the open graph template only fails to render if you have pages with "series" front matter and haven't also specified the corresponding "series" taxonomy. I personally don't think this should stop the open graph template rendering though as you lose the basic open graph fields like image etc. when you copy a page link somewhere that supports rich URLs.

Whoever sets `series` in front mattter configs without having the `series` taxonomy enabled in the site configuration should not be 'protected'.

### Issue Number:

#166

---
### 
Checklist

Yes, I included all necessary artefacts, including:

- [ ] Tests
- [ ] Documentation
- [X] Implementation (Code and Ressources)
- [ ] Example

---

### Testing Checklist

Yes, I ensured that all of the following scenarios were tested:

- [X] Desktop Light Mode (Default)
- [X] Desktop Dark Mode
- [X] Desktop Light RTL Mode
- [X] Desktop Dark RTL Mode
- [X] Mobile Light Mode
- [X] Mobile Dark Mode
- [X] Mobile Light RTL Mode
- [X] Mobile Dark RTL Mode

---

### Notify the following users

- @Xen-Echo 