### PR TITLE
fix: non styled summary

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -61,11 +61,8 @@
         {{ if .Site.Params.fullPostContent }}
           <p>{{ .Content | markdownify }}</p>
 
-
         {{ else }}
-          <p>{{ .Summary | markdownify}}</p>
-
-
+          <p>{{ .Summary | markdownify }}</p>
 
         {{ end }}
         <!-- add read more -->

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -59,11 +59,12 @@
       <div class="post__content">
         <h3><a href="{{ .RelPermalink }}">{{ upper .Title }}</a></h3>
         {{ if .Site.Params.fullPostContent }}
-          {{ .Content }}
+          <p>{{ .Content | markdownify }}</p>
 
 
         {{ else }}
-          {{ .Summary }}
+          <p>{{ .Summary | markdownify}}</p>
+
 
 
         {{ end }}


### PR DESCRIPTION
## Description

Fixes an issue where the post summary would appear as unstyled on the front page.

Before:

![image](https://user-images.githubusercontent.com/12200062/159120306-d44fbdff-291a-4db9-9724-b9d3a6540310.png)

After:

![image](https://user-images.githubusercontent.com/12200062/159120290-4a9f5bba-af2b-4c94-9164-d28be018cbe2.png)


### Issue Number:

- N/A

---

### Additional Information (Optional)

- _Here goes any Additional Information you would like to add._

---

### Checklist

Yes, I included all necessary artefacts, including:

- [ ] Tests
- [ ] Documentation
- [x] Implementation (Code and Ressources)
- [ ] Example

---

### Testing Checklist

Yes, I ensured that all of the following scenarios were tested:

- [x] Desktop Light Mode (Default)
- [x] Desktop Dark Mode
- [x] Desktop Light RTL Mode
- [x] Desktop Dark RTL Mode
- [x] Mobile Light Mode
- [x] Mobile Dark Mode
- [x] Mobile Light RTL Mode
- [x] Mobile Dark RTL Mode

---

### Notify the following users

- _List users with @ to send Notifications_
