### PR TITLE
feat: layout improvements for portfolio

### DIFF
--- a/exampleSite/data/portfolio.yml
+++ b/exampleSite/data/portfolio.yml
@@ -5,6 +5,7 @@ portfolioitems:
       - name: Project 1
         image: '/images/portfolio/code.jpg'
         link: https://gohugo.io/
+        linktext: 'Visit project website'
         description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.'
         tags:
           - Tag 1
@@ -35,15 +36,14 @@ portfolioitems:
     portfolioitem:
       - name: Project 1
         image: '/images/portfolio/code.jpg'
-        link: https://gohugo.io/
-        description: 'A description'
+        description: 'This project does not have a link attribute'
         tags:
           - Tag 1
           - Tag 2
       - name: Project 2
         image: '/images/portfolio/code.jpg'
         link: https://gohugo.io/
-        description: 'A description'
+        description: 'You can click on [**this link**](#codingprojects) to scroll to my Coding Projects portfolio'
         tags:
           - Tag 1
           - Tag 2

--- a/layouts/portfolio/list.html
+++ b/layouts/portfolio/list.html
@@ -91,7 +91,7 @@
                   {{- if .linktext -}}
                     {{ .linktext | markdownify }}
                   {{- else -}}
-                    "Visit Site"
+                    Visit Site
                   {{- end -}}
                 </a>
               </div>

--- a/layouts/portfolio/list.html
+++ b/layouts/portfolio/list.html
@@ -9,7 +9,8 @@
 
       {{ end }}"
     >
-      <h2 class="portfolio__title">{{ title .title }}</h2>
+      {{ $anchorTitle := delimit (split .title " ") "" }}
+      <h2 class="portfolio__title" id="{{ $anchorTitle | lower }}">{{ title .title }}</h2>
       {{ range $i, $p := .portfolioitem }}
         <div class="portfolio">
           {{ if .image }}
@@ -22,9 +23,13 @@
 
               {{ end }}"
             >
+            {{ if .link }}
               <a href="{{ .link | safeURL }}" target="_blank" rel="noopener">
                 <img class="portfolio__image" src="{{ .image | relURL }}" alt="{{ .name | markdownify }}" />
               </a>
+            {{ else }}
+              <img class="portfolio__image" src="{{ .image | relURL }}" alt="{{ .name | markdownify }}" />
+            {{ end }}
             </div>
 
           {{ end }}
@@ -82,7 +87,13 @@
             <p>{{ .description | markdownify }}</p>
             {{ if .link }}
               <div class="portfolio__button-wrapper">
-                <a class="portfolio__button" href="{{ .link | safeURL }}" target="_blank" rel="noopener">Visit Site</a>
+                <a class="portfolio__button" href="{{ .link | safeURL }}" target="_blank" rel="noopener">
+                  {{- if .linktext -}}
+                    {{ .linktext | markdownify }}
+                  {{- else -}}
+                    "Visit Site"
+                  {{- end -}}
+                </a>
               </div>
 
             {{ end }}

--- a/layouts/portfolio/list.html
+++ b/layouts/portfolio/list.html
@@ -23,13 +23,15 @@
 
               {{ end }}"
             >
-            {{ if .link }}
-              <a href="{{ .link | safeURL }}" target="_blank" rel="noopener">
+              {{ if .link }}
+                <a href="{{ .link | safeURL }}" target="_blank" rel="noopener">
+                  <img class="portfolio__image" src="{{ .image | relURL }}" alt="{{ .name | markdownify }}" />
+                </a>
+
+              {{ else }}
                 <img class="portfolio__image" src="{{ .image | relURL }}" alt="{{ .name | markdownify }}" />
-              </a>
-            {{ else }}
-              <img class="portfolio__image" src="{{ .image | relURL }}" alt="{{ .name | markdownify }}" />
-            {{ end }}
+
+              {{ end }}
             </div>
 
           {{ end }}
@@ -90,8 +92,10 @@
                 <a class="portfolio__button" href="{{ .link | safeURL }}" target="_blank" rel="noopener">
                   {{- if .linktext -}}
                     {{ .linktext | markdownify }}
+
                   {{- else -}}
                     Visit Site
+
                   {{- end -}}
                 </a>
               </div>


### PR DESCRIPTION
## Description

Hi!

I've prepared some suggestions for improvements of the portfolio feature:

* automatic generator of id attributes to enable support for anchor links for portfolio categories
* allow for customization of the `portfolioitem` links by adding new attribute `linktext` which can override the default `"Visit Site"` text
* generate links for a `portfolioitem` only when the `link` attribute is not empty

So far this PR does not contain tests, documentation or an example. Any suggestions are welcome!

Ondrej

### Issue Number:

n/a

---

### Additional Information (Optional)

n/a

---

### Checklist

Yes, I included all necessary artefacts, including:

- [ ] Tests
- [ ] Documentation
- [x] Implementation (Code and Ressources)
- [x] Example

---

### Testing Checklist

Yes, I ensured that all of the following scenarios were tested:

- [x] Desktop Light Mode (Default)
- [x] Desktop Dark Mode
- [ ] Desktop Light RTL Mode
- [ ] Desktop Dark RTL Mode
- [x] Mobile Light Mode
- [x] Mobile Dark Mode
- [ ] Mobile Light RTL Mode
- [ ] Mobile Dark RTL Mode

---

### Notify the following users

@lxndrblz 
