### PR TITLE
fix: loading the correct internal Google Analytics template for v4 token

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -32,7 +32,11 @@
 </footer>
 {{- partial "medium-zoom.html" .context -}}
 {{- partial "math.html" .context -}}
-{{- template "_internal/google_analytics_async.html" .context -}}
+{{- if (hasPrefix .context.Site.GoogleAnalytics "G-") -}}
+  {{- template "_internal/google_analytics.html" .context -}}
+{{- else -}}
+  {{- template "_internal/google_analytics_async.html" .context -}}
+{{- end -}}
 {{- if and (hugo.IsProduction) (.context.Site.Params.gtagId) -}}
   {{ partial "google-analytics-gtag-async.html" .context }}
 


### PR DESCRIPTION
## Description
Issue with Google Analytics v4 token. Hugo provides a separate internal template for v4 token which can be identified by their Prefix (v3 `UA-XXXXXXX-X` and v4 `G-XXXXXXXX`). 

I added an if-clause to check the prefix of googleAnalytics variable for v4 format. Loading according internal template as specified in hugo docs.

### Issue Number:

[Google Analytics v4 requires different internal Template than currently used \#339](https://github.com/lxndrblz/anatole/issues/339)

---

### Checklist

Yes, I included all necessary artefacts, including:

- [x] Tests
- [ ] Documentation
- [x] Implementation (Code and Ressources)
- [ ] Example

---

### Testing Checklist

Yes, I ensured that all of the following scenarios were tested:

- [ ] Desktop Light Mode (Default)
- [ ] Desktop Dark Mode
- [ ] Desktop Light RTL Mode
- [ ] Desktop Dark RTL Mode
- [ ] Mobile Light Mode
- [ ] Mobile Dark Mode
- [ ] Mobile Light RTL Mode
- [ ] Mobile Dark RTL Mode

---

