### PR TITLE
Use front matter description as rss item description

### DIFF
--- a/layouts/_default/rss.xml
+++ b/layouts/_default/rss.xml
@@ -34,6 +34,8 @@
       <guid>{{ .Permalink }}</guid>
       {{ if eq .Site.Params.rssFullContent true }}
         <description>{{ .Content | html }}</description>
+      {{ else if .Description }}
+        <description>{{ .Description }}</description>
       {{ else }}
         <description>{{ .Summary | html }}</description>
       {{ end }}


### PR DESCRIPTION
## Description

RSS considers content or summary as `<description></>` and ignores descriptions supplied in post front matters. This PR changes this to prefer front matter descriptions over summaries.  

### Issue Number:

#340 

---

### Checklist

Yes, I included all necessary artefacts, including:

- [ ] Tests
- [ ] Documentation
- [x] Implementation (Code and Ressources)
- [ ] Example

---

### Testing Checklist

Yes, I ensured that all of the following scenarios were tested:

- [x] Checking `/index.xml` respectively `/post/index.xml`.
- [ ] Desktop Light Mode (Default)
- [ ] Desktop Dark Mode
- [ ] Desktop Light RTL Mode
- [ ] Desktop Dark RTL Mode
- [ ] Mobile Light Mode
- [ ] Mobile Dark Mode
- [ ] Mobile Light RTL Mode
- [ ] Mobile Dark RTL Mode