### PR TITLE
fix: remove double h1 tags

### DIFF
--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -15,13 +15,15 @@
         alt="profile picture"
       />
       {{ if .IsHome }}
-      <h1 class="sidebar__introduction-title">
-        <a href="{{ .Site.BaseURL | relLangURL }}">{{ .Site.Params.Title }}</a>
-      </h1>
+        <h1 class="sidebar__introduction-title">
+          <a href="{{ .Site.BaseURL | relLangURL }}">{{ .Site.Params.Title }}</a>
+        </h1>
+
       {{ else }}
-      <div class="sidebar__introduction-title">
-        <a href="{{ .Site.BaseURL | relLangURL }}">{{ .Site.Params.Title }}</a>
-      </div>      
+        <div class="sidebar__introduction-title">
+          <a href="{{ .Site.BaseURL | relLangURL }}">{{ .Site.Params.Title }}</a>
+        </div>
+
       {{ end }}
       <div class="sidebar__introduction-description">
         <p>{{ replace .Site.Params.description "\n" "<br />" | safeHTML }}</p>

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -14,9 +14,9 @@
         src="{{ .Site.Params.profilePicture | relURL }}"
         alt="profile picture"
       />
-      <h1 class="sidebar__introduction-title">
+      <div class="sidebar__introduction-title">
         <a href="{{ .Site.BaseURL | relLangURL }}">{{ .Site.Params.Title }}</a>
-      </h1>
+      </div>
       <div class="sidebar__introduction-description">
         <p>{{ replace .Site.Params.description "\n" "<br />" | safeHTML }}</p>
       </div>

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -14,9 +14,15 @@
         src="{{ .Site.Params.profilePicture | relURL }}"
         alt="profile picture"
       />
+      {{ if .IsHome }}
+      <h1 class="sidebar__introduction-title">
+        <a href="{{ .Site.BaseURL | relLangURL }}">{{ .Site.Params.Title }}</a>
+      </h1>
+      {{ else }}
       <div class="sidebar__introduction-title">
         <a href="{{ .Site.BaseURL | relLangURL }}">{{ .Site.Params.Title }}</a>
-      </div>
+      </div>      
+      {{ end }}
       <div class="sidebar__introduction-description">
         <p>{{ replace .Site.Params.description "\n" "<br />" | safeHTML }}</p>
       </div>


### PR DESCRIPTION
## Description

Removes the duplicate H1 tag in the sidebar to improve SEO scores.

### Issue Number:

- Closes #345 

---

### Additional Information (Optional)

- _Here goes any Additional Information you would like to add._

---

### Checklist

Yes, I included all necessary artefacts, including:

- [ ] Tests
- [ ] Documentation
- [x] Implementation (Code and Ressources)
- [ ] Example

---

### Testing Checklist

Yes, I ensured that all of the following scenarios were tested:

- [x] Desktop Light Mode (Default)
- [x] Desktop Dark Mode
- [x] Desktop Light RTL Mode
- [x] Desktop Dark RTL Mode
- [x] Mobile Light Mode
- [x] Mobile Dark Mode
- [x] Mobile Light RTL Mode
- [x] Mobile Dark RTL Mode

---

### Notify the following users

- _List users with @ to send Notifications_
