### PR TITLE
open social links on a new tab

### DIFF
--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -32,7 +32,7 @@
     <ul class="sidebar__list">
       {{ range $item := .Site.Params.socialIcons }}
         <li class="sidebar__list-item">
-          <a href="{{ $item.url }}" rel="me" aria-label="{{ $item.title }}" title="{{ $item.title }}">
+          <a href="{{ $item.url }}" rel="me" target="_blank" aria-label="{{ $item.title }}" title="{{ $item.title }}">
             <i class="{{ $item.icon }} fa-2x" aria-hidden="true"></i>
           </a>
         </li>

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -32,7 +32,13 @@
     <ul class="sidebar__list">
       {{ range $item := .Site.Params.socialIcons }}
         <li class="sidebar__list-item">
-          <a href="{{ $item.url }}" rel="me" target="_blank" aria-label="{{ $item.title }}" title="{{ $item.title }}">
+          <a
+            href="{{ $item.url }}"
+            target="_blank"
+            rel="noopener"
+            aria-label="{{ $item.title }}"
+            title="{{ $item.title }}"
+          >
             <i class="{{ $item.icon }} fa-2x" aria-hidden="true"></i>
           </a>
         </li>


### PR DESCRIPTION
Hello,
I was testing your theme and one thing that annoyed me was the fact that the links to the socials didn't open on a new tab. Add this, not sure if you want to merge it.

Regards,
Renato.

## Description

Clicking on the social icons opens on the same blog page.

### Issue Number:

- _Here Goes the Issue Number with a '#'_

---

### Additional Information (Optional)

- _Here goes any Additional Information you would like to add._

---

### Checklist

Yes, I included all necessary artefacts, including:

- [x] Tests
- [ ] Documentation
- [x] Implementation (Code and Ressources)
- [ ] Example

---

### Testing Checklist

Yes, I ensured that all of the following scenarios were tested:

- [x] Desktop Light Mode (Default)
- [x] Desktop Dark Mode
- [x] Desktop Light RTL Mode
- [x] Desktop Dark RTL Mode
- [x] Mobile Light Mode
- [x] Mobile Dark Mode
- [x] Mobile Light RTL Mode
- [x] Mobile Dark RTL Mode

---

### Notify the following users

- _List users with @ to send Notifications_
@lxndrblz