### PR TITLE
the quotes wrapping the variables are escaping the title text

### DIFF
--- a/layouts/partials/schema.html
+++ b/layouts/partials/schema.html
@@ -3,7 +3,7 @@
     {
       "@context": "http://schema.org",
       "@type": "WebSite",
-      "name": "{{ .Site.Title }}",
+      "name": {{ .Site.Title | jsonify | safeJS }},
       "url": "{{ .Site.BaseURL }}",
       "description": "{{ .Site.Params.description }}",
       "thumbnailUrl": "{{ .Site.Params.Logo | absURL }}",


### PR DESCRIPTION
## Description

The quotes are escaping the title text, which is making the ld+json parsing failing.
ex: "John's blog" will be converted to "John\x27s Blog" which is not parsable as ld+json. 
Discovered using Google search console (https://search.google.com/) SEO analyse. 
Error:"Unparsable structured data > Bad escape sequence in string"
Ref: https://support.google.com/webmasters/answer/9166415#error_types

### Issue Number:

---

### Additional Information (Optional)

This seems to be a common hugo problem, for me this solution solved it. 
I saw the | jsonify | safeJS options on the thread: https://github.com/gohugoio/hugo/issues/8386

---

### Checklist

Yes, I included all necessary artefacts, including:

- [x] Tests
- [ ] Documentation
- [x] Implementation (Code and Ressources)
- [x] Example

---

### Testing Checklist

Yes, I ensured that all of the following scenarios were tested:

- [x] Desktop Light Mode (Default)
- [x] Desktop Dark Mode
- [x] Desktop Light RTL Mode
- [x] Desktop Dark RTL Mode
- [x] Mobile Light Mode
- [x] Mobile Dark Mode
- [x] Mobile Light RTL Mode
- [x] Mobile Dark RTL Mode

---

### Notify the following users

@lxndrblz 
