### PR TITLE
Adds rel-me to social links

### DIFF
--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -35,7 +35,7 @@
           <a
             href="{{ $item.url }}"
             target="_blank"
-            rel="noopener"
+            rel="noopener me"
             aria-label="{{ $item.title }}"
             title="{{ $item.title }}"
           >


### PR DESCRIPTION
[rel="me"] is a commonly used way to show that that two websites or social media accounts are the same, and is used for authentication and proving site ownership in a variety of ways.

[rel="me"]: https://indieweb.org/rel-me

## Description

_Describe the issue fixed here_

### Issue Number:

- _Here Goes the Issue Number with a '#'_

---

### Additional Information (Optional)

- _Here goes any Additional Information you would like to add._

---

### Checklist

Yes, I included all necessary artefacts, including:

- [ ] Tests
- [ ] Documentation
- [ ] Implementation (Code and Ressources)
- [ ] Example

_not applicable_

---

### Testing Checklist

Yes, I ensured that all of the following scenarios were tested:

- [ ] Desktop Light Mode (Default)
- [ ] Desktop Dark Mode
- [ ] Desktop Light RTL Mode
- [ ] Desktop Dark RTL Mode
- [ ] Mobile Light Mode
- [ ] Mobile Dark Mode
- [ ] Mobile Light RTL Mode
- [ ] Mobile Dark RTL Mode

_n/a_

---

### Notify the following users

- _List users with @ to send Notifications_
