### PR TITLE
feat: add config option to disable title capitalization

### DIFF
--- a/assets/scss/partials/components/_archive.scss
+++ b/assets/scss/partials/components/_archive.scss
@@ -32,7 +32,6 @@
     &-title {
       display: inline-block;
       flex: 0.96;
-      text-transform: uppercase;
 
       @include themed() {
         color: t('primary');

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -11,7 +11,11 @@
       {{ range .Pages }}
         <ul class="archive__list">
           <li class="archive__list-item">
+            {{ if (eq .Site.Params.disableArchiveTitleStyling true) }}
             <a class="archive__list-title" href="{{ .RelPermalink }}" title="{{ .Title }}">{{ .Title }}</a>
+            {{ else }}
+            <a class="archive__list-title" href="{{ .RelPermalink }}" title="{{ .Title }}">{{ upper .Title }}</a>
+            {{ end }}
             <div class="archive__list-date">
               {{ if isset .Site.Params "listdateformat" }}
                 {{ if .Site.Params.localizedDates }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -12,7 +12,11 @@
       </div>
     {{ end }}
     <div class="post__content">
-      <h1>{{ title .Title }}</h1>
+      {{ if (eq .Site.Params.disableTitleCapitalization true) }}
+        <h1>{{ .Title }}</h1>
+      {{ else }}
+        <h1>{{ title .Title }}</h1>
+      {{ end }}
       {{ if or (eq .Type "post") (eq .Type .Site.Params.postSectionName) }}
         <ul class="post__meta">
           <li class="post__meta-item">


### PR DESCRIPTION
## Description

Users can set disableTitleCapitalization to true in order to, well, disable title capitalization.

### Issue Number

Fixes #368


---

### Additional Information (Optional)

I wrote this on my phone so it may not work?

---

### Checklist

Yes, I included all necessary artefacts, including:

- [ ] Tests
- [ ] Documentation
- [ ] Implementation (Code and Ressources)
- [ ] Example

Documentation moved to wiki since I last contributed here, so once this PR is merged I guess the wiki could be edited?
---

### Testing Checklist

Yes, I ensured that all of the following scenarios were tested:

- [ ] Desktop Light Mode (Default)
- [ ] Desktop Dark Mode
- [ ] Desktop Light RTL Mode
- [ ] Desktop Dark RTL Mode
- [ ] Mobile Light Mode
- [ ] Mobile Dark Mode
- [ ] Mobile Light RTL Mode
- [ ] Mobile Dark RTL Mode

---

### Notify the following users

- @McPringle
- @lxndrblz 
