### PR TITLE
feat: add support to provide custom tracker script name for Umami Analytics

### DIFF
--- a/exampleSite/config/_default/params.toml
+++ b/exampleSite/config/_default/params.toml
@@ -47,6 +47,7 @@ reversepagetitle = true # When set to 'true', the Window Title will be reversed 
 [umami]
 # serverURL = "example.com"
 # id = "94db1cb1-74f4-4a40-ad6c-962362670409"
+# trackerScriptName = "mycustomscriptname.js"
 
 ## Math settings
 [math]

--- a/layouts/partials/analytics/umami.html
+++ b/layouts/partials/analytics/umami.html
@@ -1,6 +1,6 @@
 <script
   async
   defer
-  src="https://{{ .Site.Params.umami.serverURL }}/umami.js"
+  src="https://{{ .Site.Params.umami.serverURL }}/{{ .Site.Params.umami.trackerScriptName | default "umami.js" }}"
   data-website-id="{{ .Site.Params.umami.id }}"
 ></script>


### PR DESCRIPTION
## Description

Umami provides support to assign a custom name to the tracker script different from the default `umami.js` (`TRACKER_SCRIPT_NAME` environment variable) to help you avoid some ad-blockers: https://umami.is/docs/environment-variables
I have added support in Anatole to check if `trackerScriptName` is provided then use it, if not then keep using default `umami.js` as before.

Wiki documentation must be updated for the same.

### Issue Number:
No issue created.

---

### Additional Information (Optional)

- _Here goes any Additional Information you would like to add._

---

### Checklist

Yes, I included all necessary artefacts, including:

- [ ] Tests
- [ ] Documentation
- [x] Implementation (Code and Ressources)
- [x] Example

---

### Testing Checklist

Yes, I ensured that all of the following scenarios were tested:

- [x] Desktop Light Mode (Default)
- [x] Desktop Dark Mode
- [x] Desktop Light RTL Mode
- [x] Desktop Dark RTL Mode
- [x] Mobile Light Mode
- [x] Mobile Dark Mode
- [x] Mobile Light RTL Mode
- [x] Mobile Dark RTL Mode

---

### Notify the following users
@lxndrblz 