### PR TITLE
do not use wildcard to allow for monospace font in codeblock

### DIFF
--- a/assets/scss/partials/_base.scss
+++ b/assets/scss/partials/_base.scss
@@ -1,6 +1,6 @@
 @charset "UTF-8";
 
-* {
+body {
   @include ltr {
     font-family: 'PingHei', 'PingFang SC', 'Helvetica Neue', 'Work Sans', 'Hiragino Sans GB', sans-serif;
     font-size: 1.6rem;


### PR DESCRIPTION
quickfix for issue #406 

please note that is a classic "works for me" proposal, probably needs confirmation on other setups.