### PR TITLE
fix: change navbar-burger click js selector when using toc

### DIFF
--- a/assets/js/anatole-header.js
+++ b/assets/js/anatole-header.js
@@ -1,6 +1,6 @@
 document.addEventListener('DOMContentLoaded', () => {
   const navbarBurgers = Array.prototype.slice.call(document.querySelectorAll('.navbar-burger'), 0);
-  const nav = document.querySelector('nav');
+  const nav = document.querySelector('body > div > main > header > div > nav');
   if (navbarBurgers.length < 1) return;
   navbarBurgers.forEach((navbarBurger) => {
     navbarBurger.addEventListener('click', () => {


### PR DESCRIPTION
## Description

when use toc in a page, navbar-burger will can't open correctly because anatole-header.js which control nav--active select wrong element. it should select navbar-burge's nav but actually select TableOfContent's nav


### Issue Number:

- _Here Goes the Issue Number with a '#'_

---

### Additional Information (Optional)

- _Here goes any Additional Information you would like to add._

---

### Checklist

Yes, I included all necessary artefacts, including:

- [ ] Tests
- [ ] Documentation
- [ ] Implementation (Code and Ressources)
- [ ] Example

---

### Testing Checklist

Yes, I ensured that all of the following scenarios were tested:

- [ ] Desktop Light Mode (Default)
- [ ] Desktop Dark Mode
- [ ] Desktop Light RTL Mode
- [ ] Desktop Dark RTL Mode
- [ ] Mobile Light Mode
- [ ] Mobile Dark Mode
- [ ] Mobile Light RTL Mode
- [ ] Mobile Dark RTL Mode

---

### Notify the following users

- _List users with @ to send Notifications_
