### PR TITLE
Fix font color bug when switching to dark theme

### DIFF
--- a/assets/css/markupHighlight.css
+++ b/assets/css/markupHighlight.css
@@ -66,7 +66,7 @@
   --chr-cpf-color: #75715e;
 }
 
-body.theme--dark {
+:root.theme--dark {
   /* Dark -> monokai */
   --chr-def-color: #f8f8f2;
   --chr-def-bg-color: #272822;


### PR DESCRIPTION
## Description
When switching to the dark theme, some code blocks become unreadable.

### Example
Regarding this [post](https://anatole-demo.netlify.app/post/notice-shortcode/) in the example site.

#### Before
<img width="982" alt="Screenshot 2023-03-14 at 12 28 57 PM" src="https://user-images.githubusercontent.com/45718582/224992143-530d9041-214c-48b9-8f4a-2bc03b0caa79.png">

#### After
<img width="965" alt="Screenshot 2023-03-14 at 12 57 29 PM" src="https://user-images.githubusercontent.com/45718582/224993921-4b76a845-d144-47da-b5e3-24b0103d5c1f.png">


### Issue Number:

No issue was created for this PR.

---

### Checklist

Yes, I included all necessary artifacts, including:

- [ ] Tests
- [ ] Documentation
- [x] Implementation (Code and Ressources)
- [ ] Example

---

### Testing Checklist

Yes, I ensured that all of the following scenarios were tested:

- [x] Desktop Light Mode (Default)
- [x] Desktop Dark Mode
- [ ] Desktop Light RTL Mode
- [ ] Desktop Dark RTL Mode
- [x] Mobile Light Mode
- [x] Mobile Dark Mode
- [ ] Mobile Light RTL Mode
- [ ] Mobile Dark RTL Mode

---

### Notify the following users

@lxndrblz
