### PR TITLE
Fix warning when using hugo v0.112+

### DIFF
--- a/exampleSite/config/_default/languages.toml
+++ b/exampleSite/config/_default/languages.toml
@@ -6,8 +6,9 @@ contentDir = "content/english"
 
 [ar]
 title = "فلانة الفلانية"
-description = "أنا أعمل كمطورة ويب في شركة س"
 contentDir = "content/arabic" 
 weight = 2
 LanguageDirection = "rtl" 
 LanguageName = "AR"
+[ar.params]
+description = "أنا أعمل كمطورة ويب في شركة س"


### PR DESCRIPTION
When running exampleSite with hugo 0.113.0, a warning is displayed:

```
WARN 2023/06/07 22:15:10 config: languages.ar.description:
custom params on the language top level is deprecated and
will be removed in a future release. Put the value below
[languages.ar.params].
See https://gohugo.io/content-management/multilingual/#changes-in-hugo-01120
```

This PR fixes this issue.