### PR TITLE
feat(post): add description to href title

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -11,7 +11,7 @@
       {{ range .Pages }}
         <ul class="archive__list">
           <li class="archive__list-item">
-            <a class="archive__list-title" href="{{ .RelPermalink }}" title="{{ .Title }}">{{ .Title }}</a>
+            <a class="archive__list-title" href="{{ .RelPermalink }}" title="{{ .Description }}">{{ .Title }}</a>
             <div class="archive__list-date">
               {{ if isset .Site.Params "listdateformat" }}
                 {{ if .Site.Params.localizedDates }}


### PR DESCRIPTION
## Description
If #467 is accepted, this PR should not be merged
 
### Page
post (https://anatole-demo.netlify.app/post/)

### Change
The Title data is shown directly inside the `<a>Title</a>` and at the same time inside the `<a title="Title">Title</a>`.

To add more metadata to the link i propose to add the description inside the title attribute : `<a title="Description">Title</a>`

### Example 1
![image](https://github.com/lxndrblz/anatole/assets/4059615/34707cdc-1d95-4799-9454-84759209e35a)

### Example 2 - Dark theme
![image](https://github.com/lxndrblz/anatole/assets/4059615/08e8d79e-083f-4d7f-a82e-d0ee71626569)

### Checklist

Yes, I included all necessary artefacts, including:

- [x] Tests
- [x] Documentation
- [x] Implementation (Code and Ressources)
- [x] Example

---

### Testing Checklist

Yes, I ensured that all of the following scenarios were tested:

- [x] Desktop Light Mode (Default)
- [x] Desktop Dark Mode
- [x] Desktop Light RTL Mode
- [x] Desktop Dark RTL Mode
- [x] Mobile Light Mode
- [x] Mobile Dark Mode
- [x] Mobile Light RTL Mode
- [x] Mobile Dark RTL Mode
