### PR TITLE
feat: translate related posts header

### DIFF
--- a/i18n/ar.toml
+++ b/i18n/ar.toml
@@ -47,3 +47,6 @@ other = "تحديث"
 
 [series_posts]
 other = "المشاركات في هذه السلسلة"
+
+[related_posts]
+other = "مشاركات مماثلة"

--- a/i18n/de.toml
+++ b/i18n/de.toml
@@ -50,3 +50,6 @@ other = "Aktualisierung"
 
 [series_posts]
 other = "Beiträge in dieser Serie"
+
+[related_posts]
+other = "Ähnliche Beiträge"

--- a/i18n/dk.toml
+++ b/i18n/dk.toml
@@ -46,3 +46,6 @@ other = "Opdatering"
 
 [series_posts]
 other = "Indlæg i denne serie"
+
+[related_posts]
+other = "lignende indlæg"

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -50,3 +50,6 @@ other = "Update"
 
 [series_posts]
 other = "Posts in this series"
+
+[related_posts]
+other = "Related Posts"

--- a/i18n/es.toml
+++ b/i18n/es.toml
@@ -46,3 +46,6 @@ other = "Actualizar"
 
 [series_posts]
 other = "Publicaciones en esta serie"
+
+[related_posts]
+other = "Publicaciones similares"

--- a/i18n/fa.toml
+++ b/i18n/fa.toml
@@ -50,3 +50,6 @@ other = "به روز رسانی"
 
 [series_posts]
 other = "پست های این مجموعه"
+
+[related_posts]
+other = "پست های مشابه"

--- a/i18n/fi.toml
+++ b/i18n/fi.toml
@@ -46,3 +46,6 @@ other = "Päivitys"
 
 [series_posts]
 other = "Viestit tässä sarjassa"
+
+[related_posts]
+other = "Vastaavia viestejä"

--- a/i18n/fr.toml
+++ b/i18n/fr.toml
@@ -46,3 +46,6 @@ other = "mettre à jour"
 
 [series_posts]
 other = "Articles dans cette série"
+
+[related_posts]
+other = "Messages similaires"

--- a/i18n/hu.toml
+++ b/i18n/hu.toml
@@ -50,3 +50,6 @@ other = "Újdonság"
 
 [series_posts]
 other = "További bejegyzések a cikksorozatban"
+
+[related_posts]
+other = "Hasonló hozzászólások"

--- a/i18n/id.toml
+++ b/i18n/id.toml
@@ -50,3 +50,6 @@ other = "Update"
 
 [series_posts]
 other = "Posting dalam seri ini"
+
+[related_posts]
+other = "Postingan serupa"

--- a/i18n/it.toml
+++ b/i18n/it.toml
@@ -46,3 +46,6 @@ other = "Aggiorna"
 
 [series_posts]
 other = "Messaggi di questa serie"
+
+[related_posts]
+other = "Post simili"

--- a/i18n/ja.toml
+++ b/i18n/ja.toml
@@ -46,3 +46,6 @@ other = "更新"
 
 [series_posts]
 other = "このシリーズの投稿"
+
+[related_posts]
+other = "同様の投稿"

--- a/i18n/ko.toml
+++ b/i18n/ko.toml
@@ -50,3 +50,6 @@ other = "업데이트"
 
 [series_posts]
 other = "이 시리즈의 게시물"
+
+[related_posts]
+other = "비슷한 게시물"

--- a/i18n/pt-PT.toml
+++ b/i18n/pt-PT.toml
@@ -50,3 +50,6 @@ other = "Atualizar"
 
 [series_posts]
 other = "Postagens nesta série"
+
+[related_posts]
+other = "Posts semelhantes"

--- a/i18n/pt-br.toml
+++ b/i18n/pt-br.toml
@@ -46,3 +46,6 @@ other = "Atualizar"
 
 [series_posts]
 other = "Postagens nesta série"
+
+[related_posts]
+other = "Postagens semelhantes"

--- a/i18n/tr.toml
+++ b/i18n/tr.toml
@@ -50,3 +50,6 @@ other = "Güncelleme"
 
 [series_posts]
 other = "Bu serideki gönderiler"
+
+[related_posts]
+other = "Benzer gönderiler"

--- a/i18n/zh-cn.toml
+++ b/i18n/zh-cn.toml
@@ -46,3 +46,6 @@ other = "更新"
 
 [series_posts]
 other = "这个系列的帖子"
+
+[related_posts]
+other = "类似的帖子"

--- a/i18n/zh-tw.toml
+++ b/i18n/zh-tw.toml
@@ -46,3 +46,6 @@ other = "關於"
 
 [series_posts]
 other = "這個系列的帖子"
+
+[related_posts]
+other = "類似的帖子"

--- a/layouts/partials/related.html
+++ b/layouts/partials/related.html
@@ -1,9 +1,9 @@
 ﻿{{ $related := .Site.RegularPages.Related . | first .Site.Params.numberOfRelatedPosts }}
 {{ with $related }}
-  <h3>Related Posts</h3>
+  <h3>{{- T "related_posts" -}}</h3>
   <ul>
     {{ range . }}
-      <li><a href="{{ .RelPermalink }}">{{ .Title }}</a></li>
+    <li><a href="{{ .RelPermalink }}">{{ .Title }}</a></li>
     {{ end }}
   </ul>
 {{ end }}


### PR DESCRIPTION
## Description

The "Related Posts" text is currently not considered for translation. I have added the german translation as well as the i8n function call.

### Issue Number:

#472 

---

### Checklist

Yes, I included all necessary artefacts, including:

- [ ] Tests
- [ ] Documentation
- [x] Implementation (Code and Ressources)
- [ ] Example

---

### Testing Checklist

Yes, I ensured that all of the following scenarios were tested:

- [x] Desktop Light Mode (Default)
- [x] Desktop Dark Mode
- [x] Desktop Light RTL Mode
- [x] Desktop Dark RTL Mode
- [x] Mobile Light Mode
- [x] Mobile Dark Mode
- [x] Mobile Light RTL Mode
- [x] Mobile Dark RTL Mode

---
