### PR TITLE
Implement multilingual portfolio data

### DIFF
--- a/layouts/portfolio/list.html
+++ b/layouts/portfolio/list.html
@@ -1,5 +1,7 @@
 {{ define "main" }}
-  {{ range $index, $elemen:= .Site.Data.portfolio.portfolioitems }}
+  {{ $data := index .Site.Data .Site.Language.Lang "portfolio" }}
+  {{ if not $data }}{{ $data = .Site.Data.portfolio }}{{ end }}
+  {{ range $index, $elemen:= $data.portfolioitems }}
     <div
       class="post {{ with .Site.Params.doNotLoadAnimations }}
         .


### PR DESCRIPTION
## Description

This pull request implements multilingual support for portfolio data.
Data for portfolio is looked at `data/<language-code>/portfolio.yml` first and if it doesn't exists, then we use `data/portfolio.yml` like before.

### Issue Number:

#397

### Checklist

Yes, I included all necessary artefacts, including:

- [ ] Tests
- [ ] Documentation
- [X] Implementation (Code and Ressources)
- [ ] Example

I can add a spanish translation of the exampleSite and provide a working example if you want.

---

### Testing Checklist

Yes, I ensured that all of the following scenarios were tested:

- [X] Desktop Light Mode (Default)
- [X] Desktop Dark Mode
- [ ] Desktop Light RTL Mode
- [ ] Desktop Dark RTL Mode
- [X] Mobile Light Mode
- [X] Mobile Dark Mode
- [ ] Mobile Light RTL Mode
- [ ] Mobile Dark RTL Mode

There's no porfolio example for RTL mode and I don't know how to test it.

---

### Notify the following users

- _List users with @ to send Notifications_
