### PR TITLE
fix: Sidebar Title Changing Margin Size Between Home Page and Others

### DIFF
--- a/assets/scss/partials/components/_sidebar.scss
+++ b/assets/scss/partials/components/_sidebar.scss
@@ -69,6 +69,10 @@
       a {
         font-size: 3.2rem;
       }
+
+      h1 {
+        margin: 0;
+      }
     }
   }
 }

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -13,9 +13,11 @@
         alt="profile picture"
       />
       {{ if .IsHome }}
-        <h1 class="sidebar__introduction-title">
-          <a href="{{ .Site.BaseURL | relLangURL }}">{{ .Site.Params.Title }}</a>
-        </h1>
+        <div class="sidebar__introduction-title">
+          <h1>
+            <a href="{{ .Site.BaseURL | relLangURL }}">{{ .Site.Params.Title }}</a>
+          </h1>
+        </div>
       {{ else }}
         <div class="sidebar__introduction-title">
           <a href="{{ .Site.BaseURL | relLangURL }}">{{ .Site.Params.Title }}</a>


### PR DESCRIPTION
I noticed the home page side bar was repositioning items slightly when I moved from the home page to others. I had trouble finding the issue but realized it was the title (sidebar__introduction-title). On the homepage it's a h1 object and on others it's a div. I assume this is for SEO.

Both the H1 and DIV have the same CSS and same class - and even though they have the same margin of 1em, something is causing their margins to be computed differently. (For me h1 is 24px and div is 16pix). 

A workaround for this was to keep both in a div with the same class, however when it's the home page wrap the a element in a h1 element while still keeping the div. I made sure the CSS styling removes the h1 elements margin while existing within the div too.

This keeps the positioning of sidebar objects consistent between pages.

Issue related: https://github.com/lxndrblz/anatole/issues/486