### PR TITLE
fix: wordwrap in (un)ordered list

### DIFF
--- a/assets/scss/partials/components/_post.scss
+++ b/assets/scss/partials/components/_post.scss
@@ -147,6 +147,7 @@
     ol {
       line-height: 1.9em;
       font-weight: 400;
+      word-wrap: break-word;
     }
 
     img {


### PR DESCRIPTION
## Description

Fixes an issue where overly long list items would cause the viewport to extend too far horizontally.

### Issue Number:

#496

---

### Additional Information (Optional)

---

### Checklist

Yes, I included all necessary artefacts, including:

- [x] Tests
- [ ] Documentation
- [x] Implementation (Code and Ressources)
- [ ] Example

---

### Testing Checklist

Yes, I ensured that all of the following scenarios were tested:

- [x] Desktop Light Mode (Default)
- [x] Desktop Dark Mode
- [x] Desktop Light RTL Mode
- [x] Desktop Dark RTL Mode
- [x] Mobile Light Mode
- [x] Mobile Dark Mode
- [x] Mobile Light RTL Mode
- [x] Mobile Dark RTL Mode

---

### Notify the following users

- @ericswpark
