### PR TITLE
fix: remove async version of Google Analytics

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -29,8 +29,6 @@
 {{- partial "math.html" .context -}}
 {{- if (hasPrefix .context.Site.GoogleAnalytics "G-") -}}
   {{- template "_internal/google_analytics.html" .context -}}
-{{- else -}}
-  {{- template "_internal/google_analytics_async.html" .context -}}
 {{- end -}}
 {{- if and (hugo.IsProduction) (.context.Site.Params.gtagId) -}}
   {{ partial "google-analytics-gtag-async.html" .context }}


### PR DESCRIPTION
## Description

Removes the deprecated asnc version of Google Analytics.

### Issue Number:

- #493

---

### Additional Information (Optional)



---

### Checklist

Yes, I included all necessary artefacts, including:

- [ ] Tests
- [ ] Documentation
- [x] Implementation (Code and Ressources)
- [ ] Example

---

### Testing Checklist

Yes, I ensured that all of the following scenarios were tested:

- [x] Desktop Light Mode (Default)
- [x] Desktop Dark Mode
- [x] Desktop Light RTL Mode
- [x] Desktop Dark RTL Mode
- [x] Mobile Light Mode
- [x] Mobile Dark Mode
- [x] Mobile Light RTL Mode
- [x] Mobile Dark RTL Mode

---

### Notify the following users

- @McPringle
