### PR TITLE
chore: explicitly list prettier plugins

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -13,5 +13,6 @@
         "parser": "go-template"
       }
     }
-  ]
+  ],
+  "plugins": ["prettier-plugin-go-template"]
 }


### PR DESCRIPTION
## Description

In recent version the autodiscovery of Prettier is no longer supported.

See https://gohugo.io/content-management/multilingual/#changes-in-hugo-01120

### Issue Number:

---

### Additional Information (Optional)


---

### Checklist

Yes, I included all necessary artefacts, including:

- [ ] Tests
- [ ] Documentation
- [x] Implementation (Code and Ressources)
- [ ] Example

---

### Testing Checklist

Yes, I ensured that all of the following scenarios were tested:

- [ ] Desktop Light Mode (Default)
- [ ] Desktop Dark Mode
- [ ] Desktop Light RTL Mode
- [ ] Desktop Dark RTL Mode
- [ ] Mobile Light Mode
- [ ] Mobile Dark Mode
- [ ] Mobile Light RTL Mode
- [ ] Mobile Dark RTL Mode

---

### Notify the following users

