### PR TITLE
fix: remove decoration around backtick blocks

### DIFF
--- a/assets/scss/partials/components/_post.scss
+++ b/assets/scss/partials/components/_post.scss
@@ -76,12 +76,6 @@
     code {
       font-family: monospace;
       padding: 0 2px;
-
-      @include themed() {
-        background-color: t('primary-lighter');
-        border: 1px solid t('primary-lighter');
-        border-radius: 2px;
-      }
     }
 
     pre {

--- a/assets/scss/partials/components/_post.scss
+++ b/assets/scss/partials/components/_post.scss
@@ -75,7 +75,6 @@
 
     code {
       font-family: monospace;
-      padding: 0 2px;
     }
 
     pre {


### PR DESCRIPTION
Code blocks created via backticks wrap all content like in the screenshot below:
<img width="274" alt="image" src="https://github.com/lxndrblz/anatole/assets/11942223/0b77303b-3882-4544-b1d9-1843db5d1e2f">

The suggested change removes the brackets around the rendered content like so:
<img width="238" alt="image" src="https://github.com/lxndrblz/anatole/assets/11942223/8c8fad2a-e8ff-4427-b197-344bd3ed1e92">
