### PR TITLE
rename resources.ToCSS to css.Sass

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -39,7 +39,7 @@
   <!-- CSS -->
   {{ if eq .Site.Language.LanguageDirection "rtl" }}
     {{ $sassTemplate := resources.Get "scss/anatole.rtl.scss" }}
-    {{ $style := $sassTemplate | resources.ExecuteAsTemplate "scss/main.rtl.scss" . | resources.ToCSS | resources.Minify | resources.Fingerprint }}
+    {{ $style := $sassTemplate | resources.ExecuteAsTemplate "scss/main.rtl.scss" . | css.Sass | resources.Minify | resources.Fingerprint }}
     <link
       rel="stylesheet"
       href="{{ $style.RelPermalink }}"
@@ -49,7 +49,7 @@
     />
   {{ else }}
     {{ $sassTemplate := resources.Get "scss/anatole.scss" }}
-    {{ $style := $sassTemplate | resources.ExecuteAsTemplate "scss/main.scss" . | resources.ToCSS | resources.Minify | resources.Fingerprint }}
+    {{ $style := $sassTemplate | resources.ExecuteAsTemplate "scss/main.scss" . | css.Sass | resources.Minify | resources.Fingerprint }}
     <link
       rel="stylesheet"
       href="{{ $style.RelPermalink }}"


### PR DESCRIPTION
> resources.ToCSS was deprecated in Hugo v0.128.0 and will be removed in a future release. Use css.Sass instead.

see: https://github.com/gohugoio/hugo/issues/12618