### PR TITLE
Fix portfolio images on mobile

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/tomtjes/hugo-anatole
+module github.com/lxndrblz/anatole
 
 go 1.12


### PR DESCRIPTION
## Description

On small screens, i.e. my iPhone, portfolio images were cut off at the bottom.

---

### Additional Information (Optional)

Tested with smaller window sizes on desktop.

---

### Checklist

Yes, I included all necessary artefacts, including:

- [ ] Tests
- [ ] Documentation
- [X] Implementation (Code and Ressources)
- [ ] Example

---

### Testing Checklist

Yes, I ensured that all of the following scenarios were tested:

- [X] Desktop Light Mode (Default)
- [X] Desktop Dark Mode
- [ ] Desktop Light RTL Mode
- [ ] Desktop Dark RTL Mode
- [X] Mobile Light Mode
- [X] Mobile Dark Mode
- [ ] Mobile Light RTL Mode
- [ ] Mobile Dark RTL Mode

