### PR TITLE
Add support for Meta Pixel tracker

### DIFF
--- a/layouts/partials/analytics/meta.html
+++ b/layouts/partials/analytics/meta.html
@@ -12,7 +12,11 @@
       fbq('init', '{{ .pixelId }}');
       fbq('track', 'PageView');
   </script>
-  <noscript><img height="1" width="1" style="display:none"
+  <noscript
+    ><img
+      height="1"
+      width="1"
+      style="display:none"
       src="https://www.facebook.com/tr?id={{ .pixelId }}&ev=PageView&noscript=1"
   /></noscript>
 {{ end }}

--- a/layouts/partials/analytics/meta.html
+++ b/layouts/partials/analytics/meta.html
@@ -1,0 +1,18 @@
+<!-- Meta -->
+{{ with .Site.Params.meta }}
+  <script>
+      !function(f,b,e,v,n,t,s)
+      {if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+      n.callMethod.apply(n,arguments):n.queue.push(arguments)};
+      if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
+      n.queue=[];t=b.createElement(e);t.async=!0;
+      t.src=v;s=b.getElementsByTagName(e)[0];
+      s.parentNode.insertBefore(t,s)}(window, document,'script',
+      'https://connect.facebook.net/en_US/fbevents.js');
+      fbq('init', '{{ .pixelId }}');
+      fbq('track', 'PageView');
+  </script>
+  <noscript><img height="1" width="1" style="display:none"
+      src="https://www.facebook.com/tr?id={{ .pixelId }}&ev=PageView&noscript=1"
+  /></noscript>
+{{ end }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -206,6 +206,8 @@
     {{- partial "analytics/matomo" . -}}
   {{ end }}
 
+  <!-- Meta Pixel -->
+  {{- partial "analytics/meta.html" . -}}
 
   <!-- Twitter Cards -->
   {{ template "_internal/twitter_cards.html" . }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -209,7 +209,7 @@
   {{ if and hugo.IsProduction .Site.Params.meta.pixelId }}
     {{- partial "analytics/meta.html" . -}}
   {{ end }}
-  
+
 
   <!-- Twitter Cards -->
   {{ template "_internal/twitter_cards.html" . }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -206,8 +206,10 @@
     {{- partial "analytics/matomo" . -}}
   {{ end }}
 
-  <!-- Meta Pixel -->
-  {{- partial "analytics/meta.html" . -}}
+  {{ if and hugo.IsProduction .Site.Params.meta.pixelId }}
+    {{- partial "analytics/meta.html" . -}}
+  {{ end }}
+  
 
   <!-- Twitter Cards -->
   {{ template "_internal/twitter_cards.html" . }}


### PR DESCRIPTION
## Description

Add support for Meta (Facebook) Pixel tracker.

### Issue Number:

- #539

---

### Additional Information (Optional)

#### Adding Meta Pixel Analytics

To use Meta Pixel Analytics, include the following section and change the `pixelId` to the the Id of the Pixel for your domain.

```toml
[params.meta]
pixelId = 111111111111111
```

---

### Checklist

Yes, I included all necessary artefacts, including:

- [ ] Tests
- [x] Documentation
- [x] Implementation (Code and Ressources)
- [ ] Example

---

### Testing Checklist

Yes, I ensured that all of the following scenarios were tested:

- [x] Desktop Light Mode (Default)
- [x] Desktop Dark Mode
- [x] Desktop Light RTL Mode
- [x] Desktop Dark RTL Mode
- [x] Mobile Light Mode
- [x] Mobile Dark Mode
- [x] Mobile Light RTL Mode
- [x] Mobile Dark RTL Mode

---

### Notify the following users

- @lxndrblz 
