### PR TITLE
fix: clear warnings when previewing example site (hugo 0.144.2)

### DIFF
--- a/exampleSite/config/_default/hugo.toml
+++ b/exampleSite/config/_default/hugo.toml
@@ -25,7 +25,7 @@ localizedDates = false
 [markup]
     [markup.goldmark]
         [markup.goldmark.renderer]
-        unsafe=false
+        unsafe=true
 
 [taxonomies]
     category = "categories"

--- a/exampleSite/content/english/post/rich-content.md
+++ b/exampleSite/content/english/post/rich-content.md
@@ -21,9 +21,9 @@ Hugo ships with several [Built-in Shortcodes](https://gohugo.io/content-manageme
 
 ---
 
-## Twitter Simple Shortcode
+## X Simple Shortcode
 
-{{< twitter user="SanDiegoZoo" id="1453110110599868418" >}}
+{{< x user="SanDiegoZoo" id="1453110110599868418" >}}
 
 <br>
 


### PR DESCRIPTION
When previewing example site with latest hugo version 0.144.2, warnings are shown, e.g.:

```
WARN  The "twitter", "tweet", and "twitter_simple" shortcodes were deprecated in v0.142.0 and will be removed in a future release.
Please use the "x" shortcode instead.
```

This PR fixes these warnings.