### PR TITLE
Fix regression by planify post content on index

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -55,9 +55,9 @@
           <h3><a href="{{ .RelPermalink }}">{{ upper .Title }}</a></h3>
         {{ end }}
         {{ if .Site.Params.fullPostContent }}
-          <p>{{ .Content | safeHTML }}</p>
+          <p>{{ .Content | safeHTML | plainify }}</p>
         {{ else }}
-          <p>{{ .Summary | safeHTML }}</p>
+          <p>{{ .Summary | safeHTML | plainify }}</p>
         {{ end }}
         <!-- add read more -->
         {{- if and (.Truncated) (.Site.Params.readMore) -}}


### PR DESCRIPTION
## Description

Replacing `markdownify` to `safeHTML` introduced a regression. 
`markdownify` removes tags like h, a, multiple p, and returns one paragraph with plain html.
`safeHTML` returns full html with h, a multiple p.

Adding `plainify` makes output the same like with `markdownify`.
