### PR TITLE
Feat: Allow theme users to specify their own footer terms

### DIFF
--- a/exampleSite/config/_default/params.toml
+++ b/exampleSite/config/_default/params.toml
@@ -82,3 +82,7 @@ url = "mailto:mail@example.com"
 
 [mermaid]
 # enable = true
+
+[taxonomyPartials]
+categories = "taxonomy/categories.html"
+tags = "taxonomy/tags.html"

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -71,13 +71,21 @@
       {{- end -}}
     </div>
     <div class="post__footer">
+      {{/* Deprecated, use taxonomyPartials instead and define Categories as a taxonomy */}}
       {{ with .Page.Params.Categories }}
-        {{ partial "taxonomy/categories.html" . }}
+        {{ if not $.Site.Params.TaxonomyPartials.Categories }}
+          {{ partial "taxonomy/categories.html" . }}
+        {{ end }}
       {{ end }}
 
+      {{/* Deprecated, use taxonomyPartials instead and define Categories as a taxonomy */}}
       {{ with .Page.Params.Tags }}
-        {{ partial "taxonomy/tags.html" . }}
+        {{ if not $.Site.Params.TaxonomyPartials.Tags }}
+          {{ partial "taxonomy/tags.html" . }}
+        {{ end }}
       {{ end }}
+
+      {{ partial "taxonomy/taxonomy_partials.html" . }}
     </div>
 
     {{ if and (or (eq .Type "post") (eq .Type .Site.Params.postSectionName)) (ne .Page.Params.disableComments true) }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -85,13 +85,21 @@
 
           {{ end }}</span
         >
+        {{/* Deprecated, use taxonomyPartials instead and define Categories as a taxonomy */}}
         {{ with .Page.Params.Categories }}
-          {{ partial "taxonomy/categories.html" . }}
+          {{ if not $.Site.Params.TaxonomyPartials.Categories }}
+            {{ partial "taxonomy/categories.html" . }}
+          {{ end }}
         {{ end }}
 
+        {{/* Deprecated, use taxonomyPartials instead and define Categories as a taxonomy */}}
         {{ with .Page.Params.Tags }}
-          {{ partial "taxonomy/tags.html" . }}
+          {{ if not $.Site.Params.TaxonomyPartials.Tags }}
+            {{ partial "taxonomy/tags.html" . }}
+          {{ end }}
         {{ end }}
+
+        {{ partial "taxonomy/taxonomy_partials.html" . }}
       </div>
     </div>
   {{ end }}

--- a/layouts/partials/taxonomy/taxonomy_partials.html
+++ b/layouts/partials/taxonomy/taxonomy_partials.html
@@ -1,0 +1,10 @@
+{{ $pageParams := .Page.Params }}
+{{ range $taxonomy, $_ := .Site.Taxonomies }}
+  {{ with (index $pageParams $taxonomy) }}
+    {{ $terms := . }}
+    {{ with index $.Site.Params.TaxonomyPartials $taxonomy }}
+      {{ partial . $terms }}
+    {{ end }}
+  {{ end }}
+{{ end }}
+


### PR DESCRIPTION
Instead of relying only on categories and tags, this allows users to specify their own partials, and for the given taxonomies, to generate them in the footers of posts.

Now, if users want to have cute links to some terms in the footer of their posts, they just need to:
- have the taxonomy registered (see https://gohugo.io/configuration/taxonomies/),
- add a table `[params.taxonomyPartials]`, with the entries' keys equal to the plural form of the taxonomy and the values the path of the partial to be used.

For example, if there exists the following taxonomy:
```toml
[taxonomies]
  author = 'authors'
```
and a partial of name `taxonomy/authors.html`, then the following configuration will generate those partials in the footers of the articles and on the summaries of the homepage:
```toml
[params.taxonomyPartials]
authors = 'taxonomy/authors.html'
```

---

### Checklist

Yes, I included all necessary artefacts, including:

- [ ] Tests
- [ ] Documentation
- [X] Implementation (Code and Ressources)
- [ ] Example

---

### Testing Checklist

Yes, I ensured that all of the following scenarios were tested:

- [X] Desktop Light Mode (Default)
- [X] Desktop Dark Mode
- [X] Desktop Light RTL Mode
- [X] Desktop Dark RTL Mode
- [X] Mobile Light Mode
- [X] Mobile Dark Mode
- [X] Mobile Light RTL Mode
- [X] Mobile Dark RTL Mode
