### PR TITLE
Add animation on 404 content and mobile footer

### DIFF
--- a/layouts/404.html
+++ b/layouts/404.html
@@ -1,5 +1,9 @@
 {{ define "main" }}
-  <div class="page_404">
+  <div class="page_404 {{ with .Site.Params.doNotLoadAnimations }}
+      .
+    {{ else }}
+      animated fadeInDown
+    {{ end }}">
     <h1>404</h1>
     <h2>{{ i18n "page_not_found" }}</h2>
     <p>{{ i18n "page_does_not_exist" }}</p>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,5 +1,9 @@
 <footer class="footer footer__{{ .footerClassModifier }}">
-  <ul class="footer__list">
+  <ul class="footer__list {{ with .Site.Params.doNotLoadAnimations }}
+      .
+    {{ else }}
+      animated fadeInDown
+    {{ end }}">
     <li class="footer__item">
       &copy;
       {{ if isset .context.Site.Params "copyright" }}

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -1,11 +1,11 @@
 <div
-  class="sidebar{{ with .Site.Params.doNotLoadAnimations }}
+  class="sidebar"
+>
+  <div class="sidebar__content {{ with .Site.Params.doNotLoadAnimations }}
     .
   {{ else }}
     animated fadeInDown
-  {{ end }}"
->
-  <div class="sidebar__content">
+  {{ end }}">
     <div class="sidebar__introduction">
       <img
         class="sidebar__introduction-profileimage"


### PR DESCRIPTION
## Description

The 404 page's content and the footer in mobile layout were not animated with the rest of the elements if animations are not disabled.

### Checklist

Yes, I included all necessary artifacts, including:

- [ ] Tests
- [ ] Documentation
- [X] Implementation (Code and Resources)
- [ ] Example

---

### Testing Checklist

Yes, I ensured that all of the following scenarios were tested:

- [X] Desktop Light Mode (Default)
- [X] Desktop Dark Mode
- [X] Desktop Light RTL Mode
- [X] Desktop Dark RTL Mode
- [X] Mobile Light Mode
- [X] Mobile Dark Mode
- [X] Mobile Light RTL Mode
- [X] Mobile Dark RTL Mode
