### PR TITLE
fix: make setting 'contentratio' work again

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
       // Update VARIANT to pick hugo variant.
       // Example variants: hugo, hugo_extended
       // Rebuild the container if it already exists to update.
-      "VARIANT": "hugo",
+      "VARIANT": "hugo_extended",
       // Update VERSION to pick a specific hugo version.
       // Example versions: latest, 0.73.0, 0,71.1
       // Rebuild the container if it already exists to update.

--- a/.github/workflows/update-resources.yml
+++ b/.github/workflows/update-resources.yml
@@ -15,11 +15,11 @@ jobs:
         uses: peaceiris/actions-hugo@v3
         with:
           extended: true
-          hugo-version: 0.134.2
+          hugo-version: 0.147.5
       - name: setup node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
       - name: install
         run: |
           npm ci

--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@ demo/
 .hugo_build.lock
 /node_modules
 exampleSite/public/
+exampleSite/resources/
 .DS_Store
 public/

--- a/assets/scss/anatole.rtl.scss
+++ b/assets/scss/anatole.rtl.scss
@@ -1,4 +1,0 @@
-$content-ratio: {{ .Site.Params.contentratio | default 0.6 }};
-$text-direction: "rtl";
-
-@import 'main.scss';

--- a/assets/scss/anatole.scss
+++ b/assets/scss/anatole.scss
@@ -1,4 +1,0 @@
-$content-ratio: {{ .Site.Params.contentratio | default 0.6 }};
-$text-direction: "ltr";
-
-@import 'main.scss';

--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -1,3 +1,4 @@
+@import 'hugo:vars';
 @import './modules/variables';
 @import './modules/config';
 @import './modules/color_theme';

--- a/assets/scss/modules/_variables.scss
+++ b/assets/scss/modules/_variables.scss
@@ -17,9 +17,3 @@ $danger: #ef5753;
 
 $thumbnail-height: 15em;
 $body-max-width: 1920px;
-
-$sidebar-ratio: calc(1 - #{$content-ratio});
-$content-max-width: calc(#{$body-max-width} * #{$content-ratio});
-$sidebar-max-width: calc(#{$body-max-width} - #{$content-max-width});
-$content-width: calc(#{$content-ratio} * 100%);
-$sidebar-width: calc(#{$sidebar-ratio} * 100%);

--- a/assets/scss/partials/components/_wrapper.scss
+++ b/assets/scss/partials/components/_wrapper.scss
@@ -14,11 +14,11 @@
     width: 100%;
 
     @include desktop {
-      width: $content-width;
+      width: $content-ratio;
     }
 
     @include widescreen {
-      width: calc(#{$content-ratio} * 80%);
+      width: $content-ratio-wide;
     }
 
     &--fullscreen {
@@ -40,12 +40,12 @@
     padding: 16px 0;
 
     @include desktop {
-      width: $sidebar-width;
+      width: $sidebar_ratio;
       padding: 0;
     }
 
     @include widescreen {
-      width: calc(#{$sidebar-ratio} * 80%);
+      width: $sidebar_ratio_wide;
     }
 
     &--hidden {

--- a/exampleSite/config/_default/languages.toml
+++ b/exampleSite/config/_default/languages.toml
@@ -6,9 +6,9 @@ contentDir = "content/english"
 
 [ar]
 title = "فلانة الفلانية"
-contentDir = "content/arabic" 
+contentDir = "content/arabic"
 weight = 2
-LanguageDirection = "rtl" 
+LanguageDirection = "rtl"
 LanguageName = "AR"
 [ar.params]
 description = "أنا أعمل كمطورة ويب في شركة س"

--- a/exampleSite/config/_default/params.toml
+++ b/exampleSite/config/_default/params.toml
@@ -40,6 +40,9 @@ reversepagetitle = true # When set to 'true', the Window Title will be reversed 
 
 # hidesidebar = true
 
+# Sidebar/Content Ratio
+# contentratio = 0.6
+
 [simpleAnalytics]
 # enable = true
 # customurl = "https://analytics.example.com"

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -37,26 +37,37 @@
 
 
   <!-- CSS -->
-  {{ $contentRatio := or site.Params.contentratio 0.6 }}
+  {{ $contentRatio := or site.Params.contentratio 0.6 -}}
+  {{ $languageDirection := or site.Language.LanguageDirection "ltr" -}}
   {{ $vars := dict 
-    "text_direction" site.Language.LanguageDirection
-    "content_ratio" (printf "%f%%" (mul $contentRatio 100))
-    "sidebar_ratio" (printf "%f%%" (mul (sub 1.0 $contentRatio) 100))
-    "content_ratio_wide" (printf "%f%%" (mul 0.8 (mul $contentRatio 100)))
-    "sidebar_ratio_wide" (printf "%f%%" (mul 0.8 (mul (sub 1.0 $contentRatio) 100)))
-  }}
-  {{ $options := dict "transpiler" "libsass" "vars" $vars "targetPath" "anatole.css" }}
-  {{ with resources.Get "scss/main.scss" }}
-    {{ if hugo.IsProduction }}
+      "text_direction" $languageDirection
+      "content_ratio" (printf "%f%%" (mul $contentRatio 100))
+      "sidebar_ratio" (printf "%f%%" (mul (sub 1.0 $contentRatio) 100))
+      "content_ratio_wide" (printf "%f%%" (mul 0.8 (mul $contentRatio 100)))
+      "sidebar_ratio_wide" (printf "%f%%" (mul 0.8 (mul (sub 1.0 $contentRatio) 100)))
+  -}}
+  {{ $options := dict 
+      "transpiler" "libsass"
+      "vars" $vars
+      "targetPath" (printf "css/anatole%s.css" (cond (eq site.Language.LanguageDirection "") "" (printf ".%s" site.Language.LanguageDirection)))
+  -}}
+  {{ with resources.Get "scss/main.scss" -}}
+    {{ if hugo.IsProduction -}}
       {{ with . | toCSS $options | minify | fingerprint }}
-        <link rel="stylesheet" href="{{ .RelPermalink }}" integrity="{{ .Data.Integrity }}" crossorigin="anonymous">
-      {{ end }}
-    {{ else }}
+  <link rel="stylesheet"
+    href="{{ .RelPermalink }}"
+    integrity="{{ .Data.Integrity }}"
+    crossorigin="anonymous">
+      {{ end -}}
+    {{ else -}}
       {{ with . | toCSS $options }}
-        <link rel="stylesheet" href="{{ .RelPermalink }}">
-      {{ end }}
-    {{ end }}
-  {{ end }}
+  <link
+    rel="stylesheet"
+    href="{{ .RelPermalink }}"
+  />
+      {{ end -}}
+    {{ end -}}
+  {{ end -}}
 
   {{ $markupHighlightStyle := resources.Get "css/markupHighlight.css" | resources.Minify | resources.Fingerprint }}
   <link

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -37,26 +37,25 @@
 
 
   <!-- CSS -->
-  {{ if eq .Site.Language.LanguageDirection "rtl" }}
-    {{ $sassTemplate := resources.Get "scss/anatole.rtl.scss" }}
-    {{ $style := $sassTemplate | resources.ExecuteAsTemplate "scss/main.rtl.scss" . | css.Sass | resources.Minify | resources.Fingerprint }}
-    <link
-      rel="stylesheet"
-      href="{{ $style.RelPermalink }}"
-      integrity="{{ $style.Data.Integrity }}"
-      crossorigin="anonymous"
-      type="text/css"
-    />
-  {{ else }}
-    {{ $sassTemplate := resources.Get "scss/anatole.scss" }}
-    {{ $style := $sassTemplate | resources.ExecuteAsTemplate "scss/main.scss" . | css.Sass | resources.Minify | resources.Fingerprint }}
-    <link
-      rel="stylesheet"
-      href="{{ $style.RelPermalink }}"
-      integrity="{{ $style.Data.Integrity }}"
-      crossorigin="anonymous"
-      type="text/css"
-    />
+  {{ $contentRatio := or site.Params.contentratio 0.6 }}
+  {{ $vars := dict 
+    "text_direction" site.Language.LanguageDirection
+    "content_ratio" (printf "%f%%" (mul $contentRatio 100))
+    "sidebar_ratio" (printf "%f%%" (mul (sub 1.0 $contentRatio) 100))
+    "content_ratio_wide" (printf "%f%%" (mul 0.8 (mul $contentRatio 100)))
+    "sidebar_ratio_wide" (printf "%f%%" (mul 0.8 (mul (sub 1.0 $contentRatio) 100)))
+  }}
+  {{ $options := dict "transpiler" "libsass" "vars" $vars "targetPath" "anatole.css" }}
+  {{ with resources.Get "scss/main.scss" }}
+    {{ if hugo.IsProduction }}
+      {{ with . | toCSS $options | minify | fingerprint }}
+        <link rel="stylesheet" href="{{ .RelPermalink }}" integrity="{{ .Data.Integrity }}" crossorigin="anonymous">
+      {{ end }}
+    {{ else }}
+      {{ with . | toCSS $options }}
+        <link rel="stylesheet" href="{{ .RelPermalink }}">
+      {{ end }}
+    {{ end }}
   {{ end }}
 
   {{ $markupHighlightStyle := resources.Get "css/markupHighlight.css" | resources.Minify | resources.Fingerprint }}

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,7 @@
   command = "cd exampleSite && hugo --gc --minify --themesDir ../.."
   
 [build.environment]
-  HUGO_VERSION = "0.146.5"
+  HUGO_VERSION = "0.147.5"
   HUGO_ENV = "production"
   HUGO_THEME = "repo"
   HUGO_BASEURL = "https://anatole-demo.netlify.app"


### PR DESCRIPTION
## Description

As reported in #550, the site wide configuration setting `contentratio` does not work any more. This PR fixes that issue.

### Issue Number:

This PR closes #550.

### Additional Information (Optional)

With this PR applied, Sass variables are now initialize from Hugo templates in a modern, clean way. This way is described in this [discussion thread](https://discourse.gohugo.io/t/initialize-sass-variables-from-hugo-templates/42053#the-new-way-2) on hugo's discourse system.

### Checklist

Yes, I included all necessary artefacts, including:

- [ ] Tests
- [ ] Documentation
- [x] Implementation (Code and Ressources)
- [ ] Example

---

### Testing Checklist

Yes, I ensured that all of the following scenarios were tested:

- [x] Desktop Light Mode (Default)
- [x] Desktop Dark Mode
- [x] Desktop Light RTL Mode
- [x] Desktop Dark RTL Mode
- [x] Mobile Light Mode
- [x] Mobile Dark Mode
- [x] Mobile Light RTL Mode
- [x] Mobile Dark RTL Mode