### PR TITLE
Allow using custom SCSS

### DIFF
--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -27,3 +27,5 @@
 @use 'partials/vendors/contactform';
 @use 'partials/vendors/tableofcontents';
 @use 'partials/vendors/table';
+
+@use 'custom';


### PR DESCRIPTION
## Description

Instead of relying on a custom CSS file, it would be nice to have access to the theme data in custom SCSS.

Just create `custom.scss` in `assets/scss` and `@use` anything you want.

ℹ️ Note that I am not aware of potential issues with this, maybe this wasn't a feature for a reason? Please feel free to reach out if it is the case.

### Checklist

Yes, I included all necessary artefacts, including:

- [ ] Tests
- [ ] Documentation
- [X] Implementation (Code and Ressources)
- [ ] Example

---

### Testing Checklist

Yes, I ensured that all of the following scenarios were tested:

- [X] Desktop Light Mode (Default)
- [X] Desktop Dark Mode
- [X] Desktop Light RTL Mode
- [X] Desktop Dark RTL Mode
- [X] Mobile Light Mode
- [X] Mobile Dark Mode
- [X] Mobile Light RTL Mode
- [X] Mobile Dark RTL Mode
