### PR TITLE
chore: fix hugo deprecation warnings (hugo 0.157.0)

### DIFF
--- a/layouts/portfolio/list.html
+++ b/layouts/portfolio/list.html
@@ -1,6 +1,6 @@
 {{ define "main" }}
-  {{ $data := index .Site.Data .Site.Language.Lang "portfolio" }}
-  {{ if not $data }}{{ $data = .Site.Data.portfolio }}{{ end }}
+  {{ $data := index hugo.Data .Site.Language.Lang "portfolio" }}
+  {{ if not $data }}{{ $data = hugo.Data.portfolio }}{{ end }}
   {{ range $index, $elemen:= $data.portfolioitems }}
     <div
       class="post {{ with .Site.Params.doNotLoadAnimations }}

--- a/netlify.toml
+++ b/netlify.toml
@@ -12,8 +12,8 @@
 [build.environment]
   HUGO_VERSION = "0.157.0"
   DART_SASS_VERSION = "1.97.3"
-  NODE_VERSION = "22"
-  GO_VERSION = "1.24.3"
+  NODE_VERSION = "24"
+  GO_VERSION = "1.26.0"
   HUGO_ENV = "production"
   HUGO_THEME = "repo"
   HUGO_BASEURL = "https://anatole-demo.netlify.app"


### PR DESCRIPTION
When previewing the example site with latest released hugo version 0.157.0, a deprecation warning is shown:

````
INFO  deprecated: .Site.Data was deprecated in Hugo v0.156.0 and will be removed in a future release.
Use hugo.Data instead.
````

This PR fixes this issue.

**Note:**: This PR raises the minimum required hugo version to `0.156.0`.