### PR TITLE
chore: fix hugo deprecation warnings (hugo 0.158.0)

### DIFF
--- a/.github/workflows/update-resources.yml
+++ b/.github/workflows/update-resources.yml
@@ -17,7 +17,7 @@ jobs:
         uses: peaceiris/actions-hugo@v3
         with:
           extended: true
-          hugo-version: 0.157.0
+          hugo-version: 0.158.0
       - name: setup node
         uses: actions/setup-node@v6
         with:

--- a/exampleSite/config/_default/hugo.toml
+++ b/exampleSite/config/_default/hugo.toml
@@ -1,5 +1,5 @@
 baseURL = "https://example.com"
-languageCode = "en"
+locale = "en"
 DefaultContentLanguage = "en"
 title = "Website of Jane Doe"
 

--- a/exampleSite/config/_default/languages.toml
+++ b/exampleSite/config/_default/languages.toml
@@ -8,7 +8,7 @@ contentDir = "content/english"
 title = "فلانة الفلانية"
 contentDir = "content/arabic"
 weight = 2
-LanguageDirection = "rtl"
+Direction = "rtl"
 LanguageName = "AR"
 [ar.params]
 description = "أنا أعمل كمطورة ويب في شركة س"

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,6 +1,6 @@
 <!doctype html>
 <html
-  dir="{{ .Site.Language.LanguageDirection | default "ltr" }}"
+  dir="{{ .Site.Language.Direction | default "ltr" }}"
   lang="{{- site.Language.Lang -}}"
   data-theme="{{- .Site.Params.displayMode -}}"
   {{ if eq .Site.Params.displayMode "dark" }}

--- a/layouts/_default/rss.xml
+++ b/layouts/_default/rss.xml
@@ -34,7 +34,7 @@
     <title>{{ if eq  .Title  .Site.Title }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{.}} on {{ end }}{{ .Site.Title }}{{ end }}</title>
     <link>{{ .Permalink }}</link>
     <description>Recent content {{ if ne  .Title  .Site.Title }}{{ with .Title }}in {{.}} {{ end }}{{ end }}on {{ .Site.Title }}</description>
-    <generator>Hugo -- gohugo.io</generator>{{ with .Site.LanguageCode }}
+    <generator>Hugo -- gohugo.io</generator>{{ with .Site.Language.Locale }}
     <language>{{.}}</language>{{end}}{{ with $authorEmail }}
     <managingEditor>{{.}}{{ with $authorName }} ({{.}}){{end}}</managingEditor>{{end}}{{ with $authorEmail }}
     <webMaster>{{.}}{{ with $authorName }} ({{.}}){{end}}</webMaster>{{end}}{{ with .Site.Copyright }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -48,7 +48,7 @@
 
   <!-- CSS -->
   {{ $contentRatio := or site.Params.contentratio 0.6 -}}
-  {{ $languageDirection := or site.Language.LanguageDirection "ltr" -}}
+  {{ $languageDirection := or site.Language.Direction "ltr" -}}
   {{ $vars := dict
     "text_direction" $languageDirection
     "content_ratio" (printf "%f%%" (mul $contentRatio 100))
@@ -59,7 +59,7 @@
   {{ $options := dict
     "transpiler" "dartsass"
     "vars" $vars
-    "targetPath" (printf "css/anatole%s.css" (cond (eq site.Language.LanguageDirection "") "" (printf ".%s" site.Language.LanguageDirection)))
+    "targetPath" (printf "css/anatole%s.css" (cond (eq site.Language.Direction "") "" (printf ".%s" site.Language.Direction)))
   -}}
   {{ with resources.Get "scss/main.scss" -}}
     {{ if hugo.IsProduction -}}

--- a/layouts/partials/schema.html
+++ b/layouts/partials/schema.html
@@ -52,7 +52,7 @@
           {{ $copyright := replace . "{{ YEAR }}" (now.Format "2006") }}
           "copyrightYear": "{{ index (findRE `^\d{4}` $copyright 1) 0 }}",
         {{ end }}
-        "inLanguage": {{ .Site.LanguageCode | default "en-us" }},
+        "inLanguage": {{ .Site.Language.Locale | default "en-us" }},
         "isFamilyFriendly": "true",
         "mainEntityOfPage": {
             "@type": "WebPage",

--- a/layouts/partials/schema.html
+++ b/layouts/partials/schema.html
@@ -52,7 +52,7 @@
           {{ $copyright := replace . "{{ YEAR }}" (now.Format "2006") }}
           "copyrightYear": "{{ index (findRE `^\d{4}` $copyright 1) 0 }}",
         {{ end }}
-        "inLanguage": {{ .Site.Language.Locale | default "en-us" }},
+        "inLanguage": {{ (.Site.Language.Locale | default "en-us") | jsonify }},
         "isFamilyFriendly": "true",
         "mainEntityOfPage": {
             "@type": "WebPage",

--- a/netlify.toml
+++ b/netlify.toml
@@ -10,7 +10,7 @@
   """
 
 [build.environment]
-  HUGO_VERSION = "0.157.0"
+  HUGO_VERSION = "0.158.0"
   DART_SASS_VERSION = "1.97.3"
   NODE_VERSION = "24"
   GO_VERSION = "1.26.0"


### PR DESCRIPTION
## Summary

- Bumps Hugo version to **0.158.0** in CI workflow and Netlify config
- Replaces deprecated `languageCode` config key with `locale`
- Replaces deprecated `LanguageDirection` config key and template variable with `Direction`
- Replaces deprecated `.Site.LanguageCode` template variable with `.Site.Language.Locale` in `rss.xml` and `schema.html`

Follows up on #586 which addressed the same class of deprecations for Hugo 0.157.0.

## Test plan

- [ ] Build the example site locally with Hugo 0.158.0 and verify no deprecation warnings
- [ ] Check RTL layout still renders correctly for the Arabic language config
- [ ] Verify RSS feed contains a valid `<language>` element
- [ ] Verify JSON-LD schema output contains a valid `inLanguage` value

## References

docs: https://gohugo.io/methods/site/language/

cc: @lxndrblz 
