### PR TITLE
Remove duplicate inclusion of the footer.html

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -33,8 +33,6 @@
       </main>
     </div>
 
-    {{- partial "footer.html" (dict "context" . "footerClassModifier" "base") -}}
-
     {{- if (eq .Site.Params.simpleAnalytics.enable true) -}}
       {{- partial "analytics/simpleanalytics.html" . -}}
     {{- end -}}


### PR DESCRIPTION
## Description

Resolves the double inclusion of `footer.html` by removing one of the two occurences.

Result is, that `footer.html` is only included once, and any included Javascript code is only loaded **and** executed once.

### Issue Number:

#574

---

### Checklist

Yes, I included all necessary artefacts, including:

- [x] Tests
- [ ] Documentation
- [x] Implementation (Code and Ressources)
- [ ] Example

---

### Testing Checklist

Yes, I ensured that all of the following scenarios were tested:

- [x] Desktop Light Mode (Default)
- [x] Desktop Dark Mode
- [x] Desktop Light RTL Mode
- [x] Desktop Dark RTL Mode
- [x] Mobile Light Mode
- [x] Mobile Dark Mode
- [x] Mobile Light RTL Mode
- [x] Mobile Dark RTL Mode

