### PR TITLE
chore: bump min_version to 0.158.0

### DIFF
--- a/theme.toml
+++ b/theme.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/lxndrblz/anatole/"
 demosite = "https://anatole-demo.netlify.app/"
 tags = ["blog", "responsive", "clean", "minimalist", "minimal", "personal", "dark"]
 features = ["blog", "seo", "responsive", "mobile", "disqus", "fontawesome", "analytics", "math"]
-min_version = "0.128.0"
+min_version = "0.158.0"
 
 [author]
   name = "Alexander Bilz"


### PR DESCRIPTION
## Description

Since #589 the templates use `.Site.Language.Direction`, which requires Hugo 0.158.0+.
On older versions the build fails with:

```
ERROR error building site: render: [en v1.0.0 guest] failed to render pages: render of "/404" failed: "/Users/koh/github/anatole/layouts/_default/baseof.html:3:15": execute of template failed: template: 404.html:3:15: executing "404.html" at <.Site.Language.Direction>: can't evaluate field Direction in type *langs.Language
```

Bump `min_version` in `theme.toml` to `0.158.0` so Hugo warns about the incompatible version:

```
WARN  Module "anatole" is not compatible with this Hugo version: Min 0.158.0; run "hugo mod graph" for more information.
```

This makes it easier for users to realize they need to upgrade Hugo.

### Issue Number:

- None

---

### Checklist

Yes, I included all necessary artefacts, including:

- [ ] Tests
- [ ] Documentation
- [x] Implementation (Code and Ressources)
- [ ] Example

---

### Testing Checklist

Verified the exampleSite build: Hugo 0.157.0 fails with the error above, 0.158.0 succeeds.

